### PR TITLE
Added methods to client class for each supported HTTP method type

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -71,10 +71,16 @@ class Client
         }
 
         try {
-            $response = $this->httpClient->request($method, $endpoint, [
+            $params = [
                 'body' => $body,
                 'headers' => array_merge($headers, $authHeaders),
-            ]);
+            ];
+            
+            if (in_array($method, ['POST', 'PATCH', 'DELETE'])) {
+                unset($params['body']);
+            }
+
+            $response = $this->httpClient->request($method, $endpoint, $params);
         } catch (ClientException $e) {
             if ($e->getResponse()->getStatusCode() == 404) {
                 throw new NotFoundException($e->getResponse());
@@ -84,6 +90,88 @@ class Client
         }
 
         return $response;
+    }
+
+    /**
+     * Convenience method for GET requests
+     *
+     * @param string $method
+     * @param string $endpoint
+     * @param string $body
+     * @param array $headers
+     * @throws \UKFast\Exception\ApiException
+     * @throws \UKFast\Exception\NotFoundException
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function get($endpoint, $body = null, $headers = [])
+    {
+        return $this->request('GET', $endpoint, $body, $headers);
+    }
+
+    /**
+     *
+     * Convenience method for POST requests
+     *
+     * @param string $method
+     * @param string $endpoint
+     * @param string $body
+     * @param array $headers
+     * @throws \UKFast\Exception\ApiException
+     * @throws \UKFast\Exception\NotFoundException
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function post($endpoint, $body = null, $headers = [])
+    {
+        return $this->request('POST', $endpoint, $body, $headers);
+    }
+
+    /**
+     * Convenience method for PUT requests
+     *
+     * @param string $method
+     * @param string $endpoint
+     * @param string $body
+     * @param array $headers
+     * @throws \UKFast\Exception\ApiException
+     * @throws \UKFast\Exception\NotFoundException
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function put($endpoint, $body = null, $headers = [])
+    {
+        return $this->request('PUT', $endpoint, $body, $headers);
+    }
+
+    /**
+     * Convenience method for PATCH requests
+     *
+     * @param string $method
+     * @param string $endpoint
+     * @param string $body
+     * @param array $headers
+     * @throws \UKFast\Exception\ApiException
+     * @throws \UKFast\Exception\NotFoundException
+     * @return \Psr\Http\Message\ResponseInterface
+     *
+     */
+    public function patch($endpoint, $body = null, $headers = [])
+    {
+        return $this->request('PATCH', $body = null, $headers = []);
+    }
+
+    /**
+     * Convenience method for DELETE requests
+     *
+     * @param string $method
+     * @param string $endpoint
+     * @param string $body
+     * @param array $headers
+     * @throws \UKFast\Exception\ApiException
+     * @throws \UKFast\Exception\NotFoundException
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function delete($endpoint, $body = null, $headers = [])
+    {
+        return $this->request('DELETE', $body = null, $headers);
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -157,4 +157,109 @@ class ClientTest extends TestCase
 
         $this->expectException(ApiException::class);
     }
+
+    /**
+     * @test
+     */
+    public function get_sends_get_requests()
+    {
+        $mock = new MockHandler([
+            new Response(200, []),
+        ]);
+        $container = [];
+        $history = Middleware::history($container);
+        $handler = HandlerStack::create($mock);
+        $handler->push($history);
+        $guzzle = new Guzzle(['handler' => $handler]);
+        $client = new Client($guzzle);
+
+        $client->get("/");
+        
+        $this->assertEquals(1, count($container));
+        $this->assertEquals('GET', $container[0]['request']->getMethod());
+    }
+
+    /**
+     * @test
+     */
+    public function post_sends_post_requests()
+    {
+        $mock = new MockHandler([
+            new Response(200, []),
+        ]);
+        $container = [];
+        $history = Middleware::history($container);
+        $handler = HandlerStack::create($mock);
+        $handler->push($history);
+        $guzzle = new Guzzle(['handler' => $handler]);
+        $client = new Client($guzzle);
+        
+        $client->post("/");
+        
+        $this->assertEquals(1, count($container));
+        $this->assertEquals('POST', $container[0]['request']->getMethod());
+    }
+
+    /**
+     * @test
+     */
+    public function patch_sends_patch_requests()
+    {
+        $mock = new MockHandler([
+            new Response(200, []),
+        ]);
+        $container = [];
+        $history = Middleware::history($container);
+        $handler = HandlerStack::create($mock);
+        $handler->push($history);
+        $guzzle = new Guzzle(['handler' => $handler]);
+        $client = new Client($guzzle);
+        
+        $client->patch("/");
+        
+        $this->assertEquals(1, count($container));
+        $this->assertEquals('PATCH', $container[0]['request']->getMethod());
+    }
+
+    /**
+     * @test
+     */
+    public function put_sends_put_requests()
+    {
+        $mock = new MockHandler([
+            new Response(200, []),
+        ]);
+        $container = [];
+        $history = Middleware::history($container);
+        $handler = HandlerStack::create($mock);
+        $handler->push($history);
+        $guzzle = new Guzzle(['handler' => $handler]);
+        $client = new Client($guzzle);
+        
+        $client->put("/");
+        
+        $this->assertEquals(1, count($container));
+        $this->assertEquals('PUT', $container[0]['request']->getMethod());
+    }
+
+    /**
+     * @test
+     */
+    public function delete_sends_delete_requests()
+    {
+        $mock = new MockHandler([
+            new Response(200, []),
+        ]);
+        $container = [];
+        $history = Middleware::history($container);
+        $handler = HandlerStack::create($mock);
+        $handler->push($history);
+        $guzzle = new Guzzle(['handler' => $handler]);
+        $client = new Client($guzzle);
+        
+        $client->delete("/");
+        
+        $this->assertEquals(1, count($container));
+        $this->assertEquals('DELETE', $container[0]['request']->getMethod());
+    }
 }


### PR DESCRIPTION
## Related Issue

See #4 

## Changes

* Added get/post/put/patch/delete methods
* Changed request method to remove body if `POST`, `PATCH` or `DELETE`. Stops guzzle warning