### PR TITLE
Added early return for page traversal methods

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -177,7 +177,7 @@ class Page
     }
 
     /**
-     * @return \UKFast\Page
+     * @return \UKFast\Page|false
      */
     public function getNextPage()
     {
@@ -190,7 +190,7 @@ class Page
     }
 
     /**
-     * @param \UKFast\Page
+     * @return \UKFast\Page|false
      */
     public function getPreviousPage()
     {
@@ -203,7 +203,7 @@ class Page
     }
 
     /**
-     * @param \UKFast\Page
+     * @return \UKFast\Page
      */
     public function getFirstPage()
     {
@@ -212,7 +212,7 @@ class Page
     }
 
     /**
-     * @param \UKFast\Page
+     * @return \UKFast\Page
      */
     public function getLastPage()
     {

--- a/src/Page.php
+++ b/src/Page.php
@@ -181,6 +181,10 @@ class Page
      */
     public function getNextPage()
     {
+        if (!$this->nextPageUrl()) {
+            return false;
+        }
+
         $response = $this->client->request("GET", $this->nextPageUrl());
         return $this->constructNewPage($response, $this->nextPageUrl());
     }
@@ -190,6 +194,10 @@ class Page
      */
     public function getPreviousPage()
     {
+        if (!$this->previousPageUrl()) {
+            return false;
+        }
+
         $response = $this->client->request("GET", $this->previousPageUrl());
         return $this->constructNewPage($response, $this->previousPageUrl());
     }

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -115,4 +115,54 @@ class PageTest extends TestCase
         $item = $nextPage->getItems()[0];
         $this->assertEquals('2 Test Two', $item);
     }
+
+    /**
+     * @test
+     */
+    public function next_page_returns_false_if_no_next_page()
+    {
+        $page = new Page([ (object) [
+            'id' => 1,
+        ]], (object) [
+            'pagination' => (object) [
+                'total' => 1,
+                'count' => 1,
+                'per_page' => 1,
+                'total_pages' => 1,
+                'links' => (object) [
+                    'next' => null,
+                    'previous' => null,
+                    'first' => 'http://example.com/first',
+                    'last' => 'http://example.com/last'
+                ]
+            ]
+        ], new Request('GET', 'http://example.com/endpoint?per_page=1'));
+
+        $this->assertFalse($page->getNextPage());
+    }
+
+    /**
+     * @test
+     */
+    public function previous_page_returns_false_if_no_next_page()
+    {
+        $page = new Page([ (object) [
+            'id' => 1,
+        ]], (object) [
+            'pagination' => (object) [
+                'total' => 1,
+                'count' => 1,
+                'per_page' => 1,
+                'total_pages' => 1,
+                'links' => (object) [
+                    'next' => null,
+                    'previous' => null,
+                    'first' => 'http://example.com/first',
+                    'last' => 'http://example.com/last'
+                ]
+            ]
+        ], new Request('GET', 'http://example.com/endpoint?per_page=1'));
+
+        $this->assertFalse($page->getPreviousPage());
+    }
 }


### PR DESCRIPTION
## Related Issues

See #10 

## Changes

* `getNextPage` and `getLastPage` methods now return false early if there is no next/previous page link