### PR TITLE
Changed header logic to use guzzle config

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -70,7 +70,7 @@ class Client
      */
     public function request($method, $endpoint, $body = null, $headers = [])
     {
-        $defaultHeaders = ['User-Agent' => $this->getUserAgent()];
+        $defaultHeaders = $this->httpClient->getConfig()['headers'];
         if ($this->token) {
             $defaultHeaders['Authorization'] = $this->token;
         }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -53,7 +53,12 @@ class ClientTest extends TestCase
         $history = Middleware::history($container);
         $handler = HandlerStack::create($mock);
         $handler->push($history);
-        $guzzle = new Guzzle(['handler' => $handler]);
+        $guzzle = new Guzzle([
+            'handler' => $handler,
+            'headers' => [
+                'User-Agent' => 'Test/1.0'
+            ]
+        ]);
 
         $client = new Client($guzzle);
         $client->request("GET", "/");
@@ -63,11 +68,7 @@ class ClientTest extends TestCase
 
         $this->assertEquals(1, count($headers['User-Agent']));
 
-        $expected = implode(' ', [
-            'ukfast-sdk-php/' . Client::VERSION . '',
-            'php/'.PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION
-        ]);
-        $this->assertEquals($expected, $headers['User-Agent'][0]);
+        $this->assertEquals('Test/1.0', $headers['User-Agent'][0]);
     }
 
     /**
@@ -82,7 +83,12 @@ class ClientTest extends TestCase
         $history = Middleware::history($container);
         $handler = HandlerStack::create($mock);
         $handler->push($history);
-        $guzzle = new Guzzle(['handler' => $handler]);
+        $guzzle = new Guzzle([
+            'handler' => $handler,
+            'headers' => [
+                'User-Agent' => 'Test/1.0'
+            ]
+        ]);
 
         $client = new Client($guzzle);
         $client->auth('token');
@@ -93,11 +99,7 @@ class ClientTest extends TestCase
 
         $this->assertEquals(1, count($headers['User-Agent']));
 
-        $expected = implode(' ', [
-            'ukfast-sdk-php/' . Client::VERSION . '',
-            'php/'.PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION
-        ]);
-        $this->assertEquals($expected, $headers['User-Agent'][0]);
+        $this->assertEquals('Test/1.0', $headers['User-Agent'][0]);
     }
 
     /**


### PR DESCRIPTION
## Changes

* Changed header logic to use guzzle config. This should allow users to pass a custom guzzle client in, and it will use the custom headers instead of overwriting them