### PR TITLE
Added customerReference attribute to PSS Request object

### DIFF
--- a/src/Pss/Client.php
+++ b/src/Pss/Client.php
@@ -83,12 +83,16 @@ class Client extends BaseClient
         $request->archived = $item->archived;
         $request->status = $item->status;
         $request->requestSms = $item->request_sms;
+        $request->customerReference = $item->customer_reference;
 
         return $request;
     }
 
     /**
+     * Converts a response stdClass into a Reply object
      *
+     * @param $item
+     * @return \UKFast\Pss\Reply
      */
     protected function serializeReply($item)
     {

--- a/src/Pss/Request.php
+++ b/src/Pss/Request.php
@@ -4,21 +4,58 @@ namespace UKFast\Pss;
 
 class Request
 {
+    /**
+     * @var int
+     */
     public $id;
 
+    /**
+     * @var \UKFast\Pss\Author
+     */
     public $author;
 
+    /**
+     * @var string
+     */
     public $type;
 
+    /**
+     * @var string
+     */
+    public $subject;
+
+    /**
+     * @var bool
+     */
     public $secure;
 
+    /**
+     * @var \Datetime
+     */
     public $createdAt;
 
+    /**
+     * @var string
+     */
     public $priority;
 
+    /**
+     * @var bool
+     */
     public $archived;
 
+    /**
+     * @var string
+     */
     public $status;
 
+    /**
+     * @var bool
+     */
     public $requestSms;
+
+    /**
+     * @var string
+     */
+    public $customerReference;
 }

--- a/tests/PssClientTest.php
+++ b/tests/PssClientTest.php
@@ -32,6 +32,7 @@ class PssClientTest extends TestCase
                     'archived' => true,
                     'status' => 'Submitted',
                     'request_sms' => false,
+                    'customer_reference' => 'Test Reference',
                 ]],
                 'meta' => [
                     'pagination' => [
@@ -61,6 +62,7 @@ class PssClientTest extends TestCase
         $this->assertTrue($request instanceof \UKFast\Pss\Request);
         $this->assertEquals(1, $request->id);
         $this->assertEquals('First', $request->subject);
+        $this->assertEquals('Test Reference', $request->customerReference);
     }
 
     /**
@@ -132,6 +134,7 @@ class PssClientTest extends TestCase
                     'archived' => true,
                     'status' => 'Submitted',
                     'request_sms' => false,
+                    'customer_reference' => 'Test Reference',
                 ],
             ])),
         ]);
@@ -144,5 +147,6 @@ class PssClientTest extends TestCase
         $this->assertTrue($request instanceof \UKFast\Pss\Request);
         $this->assertEquals(1, $request->id);
         $this->assertEquals('First', $request->subject);
+        $this->assertEquals('Test Reference', $request->customerReference);
     }
 }


### PR DESCRIPTION
* Adds customerReference attribute to the PSS Request object which is based on `customer_reference` on API responses
* Added Docblocks to Request class to be consistent with other classes

Resolves #30