### PR TITLE
Ensure createdAt is always a DateTime

### DIFF
--- a/src/PSS/RequestClient.php
+++ b/src/PSS/RequestClient.php
@@ -2,6 +2,7 @@
 
 namespace UKFast\PSS;
 
+use DateTime;
 use UKFast\Client as BaseClient;
 
 class RequestClient extends BaseClient
@@ -56,7 +57,7 @@ class RequestClient extends BaseClient
         $request->type = $item->type;
         $request->secure = $item->secure;
         $request->subject = $item->subject;
-        $request->createdAt = $item->created_at;
+        $request->createdAt = DateTime::createFromFormat(DateTime::ISO8601, $item->created_at);
         $request->priority = $item->priority;
         $request->archived = $item->archived;
         $request->status = $item->status;

--- a/tests/PssClientTest.php
+++ b/tests/PssClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use DateTime;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Handler\MockHandler;
@@ -63,6 +64,7 @@ class PssClientTest extends TestCase
         $this->assertEquals(1, $request->id);
         $this->assertEquals('First', $request->subject);
         $this->assertEquals('Test Reference', $request->customerReference);
+        $this->assertInstanceOf(DateTime::class, $request->createdAt);
     }
 
     /**
@@ -110,6 +112,7 @@ class PssClientTest extends TestCase
         $this->assertEquals(1, $reply->author->id);
         $this->assertEquals('Jonny Test', $reply->author->name);
         $this->assertEquals('Test', $reply->description);
+        $this->assertInstanceOf(DateTime::class, $reply->createdAt);
         $this->assertEquals('2000-01-01 00:00:00', $reply->createdAt->format('Y-m-d H:i:s'));
     }
     /**
@@ -148,5 +151,6 @@ class PssClientTest extends TestCase
         $this->assertEquals(1, $request->id);
         $this->assertEquals('First', $request->subject);
         $this->assertEquals('Test Reference', $request->customerReference);
+        $this->assertInstanceOf(DateTime::class, $request->createdAt);
     }
 }


### PR DESCRIPTION
I have changed createdAt on the Request class to be a DateTime rather than the string it was before, I have then added tests to cover this change.

closes #45