### PR TITLE
remove BETA notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@ UKFast API PHP client
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 
-## Currently in beta
-
-SDK is still in development but will be fully released shortly. It's unlikely that the interface will change significantly, but it's possible that some breaking changes will be made.
-
-A PHP client library for connecting your application(s) to the UKFast APIs. 
+A PHP library for connecting your application(s) to the UKFast APIs. 
 
 To use this package, you will need a UKFast account. Sign up for free at [ukfast.co.uk][1], 
 and refer to the [Getting Started][2] section of our developer documentation for more information on consuming our APIs.
@@ -49,7 +45,7 @@ foreach ($page->getItems() as $request) {
 Contributing
 ------------
 
-We welcome contributions that will benefit our users, 
+We welcome contributions that will benefit other users, 
 please see [CONTRIBUTING](CONTRIBUTING.md) for details on how to get involved.
 
 


### PR DESCRIPTION
as we prepare to tag version one, lets remove the beta notice to let users know no significant changes will occur after this point