### PR TITLE
Change conversation to replies

### DIFF
--- a/src/PSS/Client.php
+++ b/src/PSS/Client.php
@@ -17,10 +17,10 @@ class Client extends BaseClient
     }
 
     /**
-     * @return \UKFast\SDK\PSS\ConversationClient
+     * @return \UKFast\SDK\PSS\ReplyClient
      */
-    public function conversation()
+    public function replies()
     {
-        return (new ConversationClient($this->httpClient))->auth($this->token);
+        return (new ReplyClient($this->httpClient))->auth($this->token);
     }
 }

--- a/src/PSS/ReplyClient.php
+++ b/src/PSS/ReplyClient.php
@@ -5,10 +5,10 @@ namespace UKFast\SDK\PSS;
 use UKFast\SDK\Client as BaseClient;
 use DateTime;
 
-class ConversationClient extends BaseClient
+class ReplyClient extends BaseClient
 {
     /**
-     * Gets a paginated response of all conversation replies to a ticket
+     * Gets a paginated response of all replies to a ticket
      *
      * @param int $requestId - ID of request replies belong to
      * @param int $page
@@ -18,7 +18,7 @@ class ConversationClient extends BaseClient
      */
     public function getPage($requestId, $page = 1, $perPage = 15, $filters = [])
     {
-        $page = $this->paginatedRequest("v1/requests/$requestId/conversation", $page, $perPage, $filters);
+        $page = $this->paginatedRequest("v1/requests/$requestId/replies", $page, $perPage, $filters);
         $page->serializeWith(function ($item) {
             return $this->serializeReply($item);
         });

--- a/tests/PssClientTest.php
+++ b/tests/PssClientTest.php
@@ -77,7 +77,7 @@ class PssClientTest extends TestCase
     /**
      * @test
      */
-    public function gets_a_reply()
+    public function gets_replies()
     {
         $mock = new MockHandler([
             new Response(200, [], json_encode([
@@ -127,7 +127,7 @@ class PssClientTest extends TestCase
     /**
      * @test
      */
-    public function gets_a_reply_with_attachments()
+    public function gets_replies_with_attachments()
     {
         $mock = new MockHandler([
             new Response(200, [], json_encode([

--- a/tests/PssClientTest.php
+++ b/tests/PssClientTest.php
@@ -79,7 +79,6 @@ class PssClientTest extends TestCase
      */
     public function gets_a_conversation()
     {
-//        $this->markTestSkipped();
         $mock = new MockHandler([
             new Response(200, [], json_encode([
                 'data' => [[

--- a/tests/PssClientTest.php
+++ b/tests/PssClientTest.php
@@ -77,7 +77,7 @@ class PssClientTest extends TestCase
     /**
      * @test
      */
-    public function gets_a_conversation()
+    public function gets_a_reply()
     {
         $mock = new MockHandler([
             new Response(200, [], json_encode([
@@ -111,7 +111,7 @@ class PssClientTest extends TestCase
         $guzzle = new Client(['handler' => $handler]);
 
         $client = new \UKFast\SDK\PSS\Client($guzzle);
-        $page = $client->conversation()->getPage(1);
+        $page = $client->replies()->getPage(1);
 
         $this->assertTrue($page instanceof \UKFast\SDK\Page);
 
@@ -127,7 +127,7 @@ class PssClientTest extends TestCase
     /**
      * @test
      */
-    public function gets_a_conversation_with_attachments()
+    public function gets_a_reply_with_attachments()
     {
         $mock = new MockHandler([
             new Response(200, [], json_encode([
@@ -168,7 +168,7 @@ class PssClientTest extends TestCase
         $guzzle = new Client(['handler' => $handler]);
 
         $client = new \UKFast\SDK\PSS\Client($guzzle);
-        $page = $client->conversation()->getPage(1);
+        $page = $client->replies()->getPage(1);
 
         $this->assertTrue($page instanceof \UKFast\SDK\Page);
 


### PR DESCRIPTION
The conversation endpoint was changed to replies (though conversation does still work). To be consistent with the documentation I have changed the SDK to use the newer replies endpoint

Closes #66