### PR TITLE
Added SelfResponse page type, added ability to reply to a PSS request

### DIFF
--- a/src/PSS/Entities/Author.php
+++ b/src/PSS/Entities/Author.php
@@ -21,11 +21,13 @@ class Author
 
     public function __construct($item = null)
     {
-        if (!is_null($item)) {
-            $this->id = $item->id;
-            $this->name = $item->name;
-            $this->type = $item->type;
+        if (is_null($item)) {
+            return;
         }
+
+        $this->id = $item->id;
+        $this->name = $item->name;
+        $this->type = $item->type;
     }
 
     /**

--- a/src/PSS/Entities/Author.php
+++ b/src/PSS/Entities/Author.php
@@ -19,11 +19,13 @@ class Author
      */
     public $type;
 
-    public function __construct($item)
+    public function __construct($item = null)
     {
-        $this->id = $item->id;
-        $this->name = $item->name;
-        $this->type = $item->type;
+        if (!is_null($item)) {
+            $this->id = $item->id;
+            $this->name = $item->name;
+            $this->type = $item->type;
+        }
     }
 
     /**

--- a/src/PSS/Entities/Reply.php
+++ b/src/PSS/Entities/Reply.php
@@ -5,7 +5,7 @@ namespace UKFast\SDK\PSS\Entities;
 class Reply
 {
     /**
-     * @var \UKFast\SDK\Pss\Author
+     * @var \UKFast\SDK\Pss\Entities\Author
      */
     public $author;
 

--- a/src/PSS/ReplyClient.php
+++ b/src/PSS/ReplyClient.php
@@ -45,7 +45,11 @@ class ReplyClient extends BaseClient
         $response = $this->post("v1/requests/{$requestId}/replies", $payload);
         $response = $this->decodeJson($response->getBody()->getContents());
 
-        return (new SelfResponse($response));
+        return (new SelfResponse($response))
+            ->setClient($this)
+            ->serializeWith(function ($response) {
+                return $this->serializeReply($response->data);
+            });
     }
 
     /**

--- a/src/PSS/ReplyClient.php
+++ b/src/PSS/ReplyClient.php
@@ -4,6 +4,7 @@ namespace UKFast\SDK\PSS;
 
 use UKFast\SDK\Client as BaseClient;
 use DateTime;
+use UKFast\SDK\SelfResponse;
 
 class ReplyClient extends BaseClient
 {
@@ -24,6 +25,27 @@ class ReplyClient extends BaseClient
         });
 
         return $page;
+    }
+
+    /**
+     * @param int $requestId
+     * @param \UKFast\SDK\PSS\Entities\Reply $reply
+     * @return SelfResponse
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function create($requestId, $reply)
+    {
+        $payload = json_encode([
+            'author' => [
+              'id' => $reply->author->id,
+            ],
+            'description' => $reply->description,
+        ]);
+
+        $response = $this->post("v1/requests/{$requestId}/replies", $payload);
+        $response = $this->decodeJson($response->getBody()->getContents());
+
+        return (new SelfResponse($response));
     }
 
     /**

--- a/src/SelfResponse.php
+++ b/src/SelfResponse.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace UKFast\SDK;
+
+class SelfResponse
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $location;
+
+    /**
+     * SelfResponse constructor.
+     * @param $response
+     */
+    public function __construct($response)
+    {
+        $this->id = $response->data->id;
+        $this->location = $response->meta->location;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocation()
+    {
+        return $this->location;
+    }
+}

--- a/src/SelfResponse.php
+++ b/src/SelfResponse.php
@@ -15,6 +15,16 @@ class SelfResponse
     protected $location;
 
     /**
+     * @var callable
+     */
+    protected $serializer;
+
+    /**
+     * @var \UKFast\SDK\Client
+     */
+    protected $client;
+
+    /**
      * SelfResponse constructor.
      * @param $response
      */
@@ -22,6 +32,47 @@ class SelfResponse
     {
         $this->id = $response->data->id;
         $this->location = $response->meta->location;
+    }
+
+    /**
+     * Return the newly created resource
+     * @return mixed
+     */
+    public function get()
+    {
+        $response = $this->client->request("GET", $this->getLocation());
+        $response->getBody()->rewind();
+        $response = json_decode($response->getBody()->getContents());
+
+        $serializer = $this->serializer;
+
+        return $serializer($response);
+    }
+
+    /**
+     * Sets client to use when making requests
+     * to other pages
+     *
+     * @param \UKFast\SDK\Client $client
+     * @return \UKFast\SDK\SelfResponse
+     */
+    public function setClient(Client $client)
+    {
+        $this->client = $client;
+        return $this;
+    }
+
+    /**
+     * Sets a mapping function to serialize each
+     * item in a new page with
+     *
+     * @param \Closure $callback
+     * @return \UKFast\SDK\SelfResponse
+     */
+    public function serializeWith($callback)
+    {
+        $this->serializer = $callback;
+        return $this;
     }
 
     /**

--- a/tests/SelfResponseTest.php
+++ b/tests/SelfResponseTest.php
@@ -12,11 +12,11 @@ class SelfResponseTest extends TestCase
      */
     public function parses_data_and_meta()
     {
-        $response = [
-            'data' => [
+        $response = (object) [
+            'data' => (object) [
                 'id' => 23
             ],
-            'meta' => [
+            'meta' => (object) [
                 'location' => 'https://example.com/23'
             ],
         ];

--- a/tests/SelfResponseTest.php
+++ b/tests/SelfResponseTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use UKFast\SDK\SelfResponse;
+
+class SelfResponseTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function parses_data_and_meta()
+    {
+        $response = [
+            'data' => [
+                'id' => 23
+            ],
+            'meta' => [
+                'location' => 'https://example.com/23'
+            ],
+        ];
+
+        $selfResponse = new SelfResponse($response);
+
+        $this->assertEquals(23, $selfResponse->getId());
+        $this->assertEquals('https://example.com/23', $selfResponse->getLocation());
+    }
+}


### PR DESCRIPTION
Resolves #68 

Example Usage:
```php
<?php

require_once "./vendor/autoload.php";

$author = new \UKFast\SDK\PSS\Entities\Author;
$author->id = 1;

$reply = new \UKFast\SDK\PSS\Entities\Reply;
$reply->author = $author;
$reply->description = "test description goes here\nwith a new line";

$pss = (new \UKFast\SDK\PSS\Client)->auth('REDACTED');
try {
    $response = $pss->replies()->create(1, $reply);
} catch (\UKFast\SDK\Exception\ApiException $e) {
    var_dump($e->getErrors());
} catch (\Exception $e) {
    var_dump($e->getMessage());
}
```