### PR TITLE
Added ability to create a support request

### DIFF
--- a/src/PSS/Entities/Product.php
+++ b/src/PSS/Entities/Product.php
@@ -18,8 +18,12 @@ class Product
      * Product constructor.
      * @param $item
      */
-    public function __construct($item)
+    public function __construct($item = null)
     {
+        if (is_null($item)) {
+            return;
+        }
+        
         $this->id = $item->id;
         $this->type = $item->type;
     }

--- a/src/PSS/Entities/Request.php
+++ b/src/PSS/Entities/Request.php
@@ -27,7 +27,7 @@ class Request
     /**
      * @var bool
      */
-    public $secure;
+    public $secure = true;
 
     /**
      * @var \Datetime
@@ -37,7 +37,7 @@ class Request
     /**
      * @var string
      */
-    public $priority;
+    public $priority = 'Normal';
 
     /**
      * @var bool
@@ -52,7 +52,7 @@ class Request
     /**
      * @var bool
      */
-    public $requestSms;
+    public $requestSms = false;
 
     /**
      * @var string
@@ -68,4 +68,9 @@ class Request
      * @var \DateTime
      */
     public $lastRepliedAt;
+
+    /**
+     * @var string
+     */
+    public $details;
 }

--- a/src/PSS/RequestClient.php
+++ b/src/PSS/RequestClient.php
@@ -4,6 +4,7 @@ namespace UKFast\SDK\PSS;
 
 use DateTime;
 use UKFast\SDK\Client as BaseClient;
+use UKFast\SDK\SelfResponse;
 
 class RequestClient extends BaseClient
 {
@@ -38,6 +39,46 @@ class RequestClient extends BaseClient
         $response = $this->request("GET", "v1/requests/$id");
         $body = $this->decodeJson($response->getBody()->getContents());
         return $this->serializeRequest($body->data);
+    }
+
+    /**
+     * @param $request
+     * @return SelfResponse
+     */
+    public function create($request)
+    {
+        $payload = [
+            'subject' => $request->subject,
+            'details' => $request->details,
+            'priority' => $request->priority,
+            'secure' => $request->secure,
+            'author' => [
+                'id' => $request->author->id
+            ],
+            'request_sms' => $request->requestSms,
+        ];
+
+        if ($request->product) {
+            $payload['product'] = [
+                'type' => $request->product->type,
+                'id' => $request->product->id,
+            ];
+        }
+
+        if ($request->customerReference) {
+            $payload['customer_reference'] = $request->customerReference;
+        }
+
+        $payload = json_encode($payload);
+
+        $response = $this->post("v1/requests", $payload);
+        $response = $this->decodeJson($response->getBody()->getContents());
+
+        return (new SelfResponse($response))
+            ->setClient($this)
+            ->serializeWith(function ($response) {
+                return $this->serializeRequest($response->data);
+            });
     }
 
 


### PR DESCRIPTION
Example usage:

```php
<?php

require_once "./vendor/autoload.php";

$author = new \UKFast\SDK\PSS\Entities\Author;
$author->id = 1;

$product = new \UKFast\SDK\PSS\Entities\Product;
$product->type = 'Domains';
$product->id = 100;

$request = new \UKFast\SDK\PSS\Entities\Request();
$request->author = $author;
$request->product = $product;
$request->subject = 'test sdk subject';
$request->details = "Test\nTest";
$request->priority = "High";

$pss = (new \UKFast\SDK\PSS\Client)->auth(***');
try {

    $response = $pss->requests()->create($request);
    var_dump($response->get());
} catch (\UKFast\SDK\Exception\ApiException $e) {
    var_dump($e->getErrors());
} catch (\Exception $e) {
    var_dump($e->getMessage());
}
```