### PR TITLE
Add Invoice and InvoiceQuery to the SDK

### DIFF
--- a/src/Account/Client.php
+++ b/src/Account/Client.php
@@ -31,4 +31,20 @@ class Client extends BaseClient
     {
         return (new CreditClient($this->httpClient))->auth($this->token);
     }
+
+    /**
+     * @return BaseClient
+     */
+    public function invoices()
+    {
+        return (new InvoiceClient($this->httpClient))->auth($this->token);
+    }
+
+    /**
+     * @return BaseClient
+     */
+    public function invoiceQueries()
+    {
+        return (new InvoiceQueryClient($this->httpClient))->auth($this->token);
+    }
 }

--- a/src/Account/Entities/Invoice.php
+++ b/src/Account/Entities/Invoice.php
@@ -28,7 +28,7 @@ class Invoice
 
     /**
      * Invoice constructor.
-     * 
+     *
      * @param null $item
      */
     public function __construct($item = null)

--- a/src/Account/Entities/Invoice.php
+++ b/src/Account/Entities/Invoice.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace UKFast\SDK\Account\Entities;
+
+use DateTime;
+
+class Invoice
+{
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var \Datetime
+     */
+    public $date;
+
+    /**
+     * @var bool
+     */
+    public $paid;
+
+    /**
+     * @var float
+     */
+    public $amount;
+
+    /**
+     * Invoice constructor.
+     * 
+     * @param null $item
+     */
+    public function __construct($item = null)
+    {
+        if (empty($item)) {
+            return;
+        }
+
+        $this->id = $item->id;
+        $this->date = DateTime::createFromFormat('Y-m-d', $item->date);
+        $this->paid = $item->paid;
+        $this->amount = $item->amount;
+    }
+}

--- a/src/Account/Entities/InvoiceQuery.php
+++ b/src/Account/Entities/InvoiceQuery.php
@@ -40,6 +40,11 @@ class InvoiceQuery
     public $invoice_ids;
 
     /**
+     * @var string
+     */
+    public $contact_method;
+
+    /**
      * InvoiceQuery constructor.
      * 
      * @param null $item
@@ -57,5 +62,6 @@ class InvoiceQuery
         $this->whatWasReceived = $item->what_was_received;
         $this->proposedSolution = $item->proposed_solution;
         $this->invoiceIds = $item->invoice_ids;
+        $this->contactMethod = $item->contact_method;
     }
 }

--- a/src/Account/Entities/InvoiceQuery.php
+++ b/src/Account/Entities/InvoiceQuery.php
@@ -12,7 +12,7 @@ class InvoiceQuery
     /**
      * @var int
      */
-    public $contact_id;
+    public $contactId;
 
     /**
      * @var int
@@ -22,27 +22,27 @@ class InvoiceQuery
     /**
      * @var string
      */
-    public $what_was_expected;
+    public $whatWasExpected;
 
     /**
      * @var string
      */
-    public $what_was_received;
+    public $whatWasReceived;
 
     /**
      * @var string
      */
-    public $proposed_solution;
+    public $proposedSolution;
 
     /**
      * @var array
      */
-    public $invoice_ids;
+    public $invoiceIds;
 
     /**
      * @var string
      */
-    public $contact_method;
+    public $contactMethod;
 
     /**
      * InvoiceQuery constructor.

--- a/src/Account/Entities/InvoiceQuery.php
+++ b/src/Account/Entities/InvoiceQuery.php
@@ -46,7 +46,7 @@ class InvoiceQuery
 
     /**
      * InvoiceQuery constructor.
-     * 
+     *
      * @param null $item
      */
     public function __construct($item = null)

--- a/src/Account/Entities/InvoiceQuery.php
+++ b/src/Account/Entities/InvoiceQuery.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace UKFast\SDK\Account\Entities;
+
+class InvoiceQuery
+{
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var int
+     */
+    public $contact_id;
+
+    /**
+     * @var int
+     */
+    public $amount;
+
+    /**
+     * @var string
+     */
+    public $what_was_expected;
+
+    /**
+     * @var string
+     */
+    public $what_was_received;
+
+    /**
+     * @var string
+     */
+    public $proposed_solution;
+
+    /**
+     * @var array
+     */
+    public $invoice_ids;
+
+    /**
+     * InvoiceQuery constructor.
+     * 
+     * @param null $item
+     */
+    public function __construct($item = null)
+    {
+        if (empty($item)) {
+            return;
+        }
+
+        $this->id = $item->id;
+        $this->contactId = $item->contact_id;
+        $this->amount = $item->amount;
+        $this->whatWasExpected = $item->what_was_expected;
+        $this->whatWasReceived = $item->what_was_received;
+        $this->proposedSolution = $item->proposed_solution;
+        $this->invoiceIds = $item->invoice_ids;
+    }
+}

--- a/src/Account/InvoiceClient.php
+++ b/src/Account/InvoiceClient.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace UKFast\SDK\Account;
+
+use UKFast\SDK\Account\Entities\Invoice;
+use UKFast\SDK\Client as BaseClient;
+use UKFast\SDK\Page;
+use UKFast\SDK\SelfResponse;
+
+class InvoiceClient extends BaseClient
+{
+    protected $basePath = 'account/';
+    
+    /**
+     * Gets a paginated response of all Invoices
+     *
+     * @param int $page
+     * @param int $perPage
+     * @param array $filters
+     * @return Page
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getPage($page = 1, $perPage = 15, $filters = [])
+    {
+        $page = $this->paginatedRequest('v1/invoices', $page, $perPage, $filters);
+        $page->serializeWith(function ($item) {
+            return new Invoice($item);
+        });
+
+        return $page;
+    }
+
+    /**
+     * Gets an individual invoice
+     *
+     * @param string $id
+     * @return Invoice
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getById($id)
+    {
+        $response = $this->request("GET", "v1/invoices/$id");
+        $body = $this->decodeJson($response->getBody()->getContents());
+        return new Invoice($body->data);
+    }
+}

--- a/src/Account/InvoiceQueryClient.php
+++ b/src/Account/InvoiceQueryClient.php
@@ -24,4 +24,57 @@ class InvoiceQueryClient extends BaseClient
         $body = $this->decodeJson($response->getBody()->getContents());
         return new InvoiceQuery($body->data);
     }
+
+    /**
+     * @param $invoiceQuery
+     * @return SelfResponse
+     */
+    public function create($invoiceQuery)
+    {
+        $response = $this->post("v1/invoices/query", $this->invoiceQueryToJson($invoiceQuery));
+        $response = $this->decodeJson($response->getBody()->getContents());
+
+        return (new SelfResponse($response))
+            ->setClient($this)
+            ->serializeWith(function ($response) {
+                return $this->serializeInvoiceQuery($response->data);
+            });
+    }
+
+    /**
+     * Converts a response stdClass into an InvoiceQuery object
+     *
+     * @param \stdClass
+     * @return \UKFast\SDK\Account\Entities\InvoiceQuery
+     */
+    protected function serializeInvoiceQuery($item)
+    {
+        $invoiceQuery = new Entities\InvoiceQuery;
+
+        $invoiceQuery->id = $item->id;
+        $invoiceQuery->contactId = $item->contact_id;
+        $invoiceQuery->amount = $item->amount;
+        $invoiceQuery->whatWasExpected = $item->what_was_expected;
+        $invoiceQuery->whatWasReceived = $item->what_was_received;
+        $invoiceQuery->proposedSolution = $item->proposed_solution;
+        $invoiceQuery->invoiceIds = $item->invoice_ids;
+        $invoiceQuery->contactMethod = $item->contact_method;
+
+        return $invoiceQuery;
+    }
+
+    protected function invoiceQueryToJson($invoiceQuery)
+    {
+        $payload = [
+            'contact_id' => $invoiceQuery->contactId,
+            'amount' => $invoiceQuery->amount,
+            'what_was_expected' => $invoiceQuery->whatWasExpected,
+            'what_was_received' => $invoiceQuery->whatWasReceived,
+            'proposed_solution' => $invoiceQuery->proposedSolution,
+            'invoice_ids' => $invoiceQuery->invoiceIds,
+            'contact_method' => $invoiceQuery->contactMethod,
+        ];
+
+        return json_encode($payload);
+    }
 }

--- a/src/Account/InvoiceQueryClient.php
+++ b/src/Account/InvoiceQueryClient.php
@@ -49,16 +49,7 @@ class InvoiceQueryClient extends BaseClient
      */
     protected function serializeInvoiceQuery($item)
     {
-        $invoiceQuery = new Entities\InvoiceQuery;
-
-        $invoiceQuery->id = $item->id;
-        $invoiceQuery->contactId = $item->contact_id;
-        $invoiceQuery->amount = $item->amount;
-        $invoiceQuery->whatWasExpected = $item->what_was_expected;
-        $invoiceQuery->whatWasReceived = $item->what_was_received;
-        $invoiceQuery->proposedSolution = $item->proposed_solution;
-        $invoiceQuery->invoiceIds = $item->invoice_ids;
-        $invoiceQuery->contactMethod = $item->contact_method;
+        $invoiceQuery = new Entities\InvoiceQuery($item);
 
         return $invoiceQuery;
     }

--- a/src/Account/InvoiceQueryClient.php
+++ b/src/Account/InvoiceQueryClient.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace UKFast\SDK\Account;
+
+use UKFast\SDK\Account\Entities\InvoiceQuery;
+use UKFast\SDK\Client as BaseClient;
+use UKFast\SDK\Page;
+use UKFast\SDK\SelfResponse;
+
+class InvoiceQueryClient extends BaseClient
+{
+    protected $basePath = 'account/';
+
+    /**
+     * Gets an individual invoice query
+     *
+     * @param string $id
+     * @return InvoiceQuery
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getById($id)
+    {
+        $response = $this->request("GET", "v1/invoices/query/$id");
+        $body = $this->decodeJson($response->getBody()->getContents());
+        return new InvoiceQuery($body->data);
+    }
+}

--- a/tests/Account/InvoiceQueryTest.php
+++ b/tests/Account/InvoiceQueryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Account;
+
+use DateTime;
+use GuzzleHttp\Client as Guzzle;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use UKFast\SDK\Account\Entities\InvoiceQuery;
+
+class InvoiceQueryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function get_invoice_query_by_id()
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                "data" => [
+                    "id" => 1,
+                    "contact_id" => 1,
+                    "amount" => 5000,
+                    "what_was_expected" => "I didn't get the full amount",
+                    "what_was_received" => "4500",
+                    "proposed_solution" => "Resolve the difference",
+                    "invoice_ids" => [
+                            2514571,
+                            2456789,
+                            1245678
+                    ]
+                ],
+                "meta" => []
+            ])),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $guzzle = new Guzzle(['handler' => $handler]);
+
+        $id = 1;
+
+        $client = new \UKFast\SDK\Account\Client($guzzle);
+        $invoiceQuery = $client->invoiceQueries()->getById($id);
+
+        $this->assertTrue($invoiceQuery instanceof \UKFast\SDK\Account\Entities\InvoiceQuery);
+        $this->assertEquals($id, $invoiceQuery->id);
+        $this->assertEquals(1, $invoiceQuery->contactId);
+        $this->assertEquals(5000, $invoiceQuery->amount);
+        $this->assertEquals("I didn't get the full amount", $invoiceQuery->whatWasExpected);
+        $this->assertEquals("4500", $invoiceQuery->whatWasReceived);
+        $this->assertEquals("Resolve the difference", $invoiceQuery->proposedSolution);
+        $this->assertEquals([2514571, 2456789, 1245678], $invoiceQuery->invoiceIds);
+    }
+}

--- a/tests/Account/InvoiceQueryTest.php
+++ b/tests/Account/InvoiceQueryTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use UKFast\SDK\SelfResponse;
 use UKFast\SDK\Account\Entities\InvoiceQuery;
 
 class InvoiceQueryTest extends TestCase
@@ -30,7 +31,8 @@ class InvoiceQueryTest extends TestCase
                             2514571,
                             2456789,
                             1245678
-                    ]
+                    ],
+                    "contact_method" => "email"
                 ],
                 "meta" => []
             ])),
@@ -52,5 +54,26 @@ class InvoiceQueryTest extends TestCase
         $this->assertEquals("4500", $invoiceQuery->whatWasReceived);
         $this->assertEquals("Resolve the difference", $invoiceQuery->proposedSolution);
         $this->assertEquals([2514571, 2456789, 1245678], $invoiceQuery->invoiceIds);
+        $this->assertEquals("email", $invoiceQuery->contact_method);
+    }
+
+    /**
+     * @test
+     */
+    public function check_self_response_parses_query_response()
+    {
+        $response = (object) [
+            'data' => (object) [
+                'id' => 123
+            ],
+            'meta' => (object) [
+                'location' => 'https://api.ukfast.io/v1/invoices/query/123'
+            ],
+        ];
+
+        $selfResponse = new SelfResponse($response);
+
+        $this->assertEquals(123, $selfResponse->getId());
+        $this->assertEquals('https://api.ukfast.io/v1/invoices/query/123', $selfResponse->getLocation());
     }
 }

--- a/tests/Account/InvoiceQueryTest.php
+++ b/tests/Account/InvoiceQueryTest.php
@@ -54,7 +54,7 @@ class InvoiceQueryTest extends TestCase
         $this->assertEquals("4500", $invoiceQuery->whatWasReceived);
         $this->assertEquals("Resolve the difference", $invoiceQuery->proposedSolution);
         $this->assertEquals([2514571, 2456789, 1245678], $invoiceQuery->invoiceIds);
-        $this->assertEquals("email", $invoiceQuery->contact_method);
+        $this->assertEquals("email", $invoiceQuery->contactMethod);
     }
 
     /**

--- a/tests/Account/InvoiceTest.php
+++ b/tests/Account/InvoiceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Account;
+
+use DateTime;
+use GuzzleHttp\Client as Guzzle;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use UKFast\SDK\Account\Entities\Invoice;
+
+class InvoiceTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function get_page_of_invoices()
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                'data' => [
+                    [
+                        'id' => 1,
+                        "date" => "2019-08-13",
+                        "paid" => true,
+                        "amount" => 100.10,
+                    ],
+                    [
+                        "id" => 54110,
+                        "date" => "2006-10-26",
+                        "paid" => true,
+                        "amount" => 52.89,
+                    ]
+                ],
+                "meta" => [
+                    "pagination" => [
+                        "total" => 40,
+                        "count" => 40,
+                        "per_page" => 100,
+                        "current_page" => 1,
+                        "total_pages" => 1,
+                        "links" => []
+                    ]
+                ]
+            ])),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $guzzle = new Guzzle(['handler' => $handler]);
+
+        $client = new \UKFast\SDK\Account\Client($guzzle);
+        $page = $client->invoices()->getPage();
+
+        $this->assertTrue($page instanceof \UKFast\SDK\Page);
+        $request = $page->getItems()[0];
+
+        $this->assertTrue($request instanceof \UKFast\SDK\Account\Entities\Invoice);
+        $this->assertEquals(1, $request->id);
+        $this->assertInstanceOf(DateTime::class, $request->date);
+        $this->assertEquals(true, $request->paid);
+        $this->assertEquals(100.10, $request->paid);
+    }
+
+    /**
+     * @test
+     */
+    public function get_invoice_by_id()
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                'data' => [
+                    'id' => 1,
+                    "date" => "2019-08-14",
+                    "paid" => true,
+                    "amount" => 150.10,
+                ],
+                "meta" => []
+            ])),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $guzzle = new Guzzle(['handler' => $handler]);
+
+        $id = 1;
+
+        $client = new \UKFast\SDK\Account\Client($guzzle);
+        $invoice = $client->invoices()->getById($id);
+
+        $this->assertTrue($invoice instanceof \UKFast\SDK\Account\Entities\Invoice);
+        $this->assertEquals($id, $invoice->id);
+        $this->assertInstanceOf(DateTime::class, $invoice->date);
+        $this->assertEquals(true, $invoice->paid);
+        $this->assertEquals(100.10, $invoice->paid);
+    }
+}


### PR DESCRIPTION
- Added `Invoice` and `InvoiceQuery` clients and entities.
- Added tests for `get` and `getById` requests and for the `SelfResponse` function on InvoiceQuery responses.