### PR TITLE
Create entities and methods for authorisation agreements

### DIFF
--- a/src/LTaaS/AgreementClient.php
+++ b/src/LTaaS/AgreementClient.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace UKFast\SDK\LTaaS;
+
+use GuzzleHttp\Exception\GuzzleException;
+use UKFast\SDK\LTaaS\Entities\Agreement;
+use UKFast\SDK\Page;
+
+class AgreementClient extends Client
+{
+    protected $basePath = 'ltaas/';
+
+    /**
+     * Get the latest authorisation agreement
+     * @return Agreement
+     * @throws GuzzleException
+     */
+    public function latest()
+    {
+        $response = $this->get('v1/agreements/latest');
+
+        $body = $this->decodeJson($response->getBody()->getContents());
+
+        return new Agreement($body->data);
+    }
+}

--- a/src/LTaaS/Client.php
+++ b/src/LTaaS/Client.php
@@ -47,4 +47,9 @@ class Client extends BaseClient
     {
         return (new ThresholdClient($this->httpClient))->auth($this->token);
     }
+
+    public function agreements()
+    {
+        return (new AgreementClient($this->httpClient))->auth($this->token);
+    }
 }

--- a/src/LTaaS/DomainClient.php
+++ b/src/LTaaS/DomainClient.php
@@ -69,7 +69,8 @@ class DomainClient extends Client
     public function create(Domain $domain)
     {
         $data = [
-            'name' => $domain->name
+            'name' => $domain->name,
+            'verification_method' => $domain->verificationMethod
         ];
 
         $response = $this->post('v1/domains', json_encode($data));

--- a/src/LTaaS/Entities/Agreement.php
+++ b/src/LTaaS/Entities/Agreement.php
@@ -14,16 +14,6 @@ class Agreement
      */
     public $agreement;
 
-    /**
-     * @var string
-     */
-    public $createdAt;
-
-    /**
-     * @var string
-     */
-    public $updatedAt;
-
     public function __construct($item = null)
     {
         if (is_null($item)) {
@@ -32,7 +22,5 @@ class Agreement
 
         $this->version = $item->version;
         $this->agreement = $item->agreement;
-        $this->createdAt = $item->created_at;
-        $this->updatedAt = $item->updated_at;
     }
 }

--- a/src/LTaaS/Entities/Agreement.php
+++ b/src/LTaaS/Entities/Agreement.php
@@ -7,7 +7,7 @@ class Agreement
     /**
      * @var string
      */
-    public $id;
+    public $version;
 
     /**
      * @var string
@@ -30,7 +30,7 @@ class Agreement
             return;
         }
 
-        $this->id = $item->id;
+        $this->version = $item->version;
         $this->agreement = $item->agreement;
         $this->createdAt = $item->created_at;
         $this->updatedAt = $item->updated_at;

--- a/src/LTaaS/Entities/Agreement.php
+++ b/src/LTaaS/Entities/Agreement.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace UKFast\SDK\LTaaS\Entities;
+
+class Agreement
+{
+    /**
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @var string
+     */
+    public $agreement;
+
+    /**
+     * @var string
+     */
+    public $createdAt;
+
+    /**
+     * @var string
+     */
+    public $updatedAt;
+
+    public function __construct($item = null)
+    {
+        if (is_null($item)) {
+            return;
+        }
+
+        $this->id = $item->id;
+        $this->agreement = $item->agreement;
+        $this->createdAt = $item->created_at;
+        $this->updatedAt = $item->updated_at;
+    }
+}

--- a/src/LTaaS/Entities/Domain.php
+++ b/src/LTaaS/Entities/Domain.php
@@ -55,8 +55,8 @@ class Domain
         }
 
         $this->id = $item->id;
-        $this->name = $item->name;
-        $this->status = $item->status;
+        $this->name = (isset($item->name)) ? $item->name : null;
+        $this->status = (isset($item->status)) ? $item->status : null;
         $this->verificationMethod = (isset($item->verification_method)) ? $item->verification_method : null;
         $this->verificationString = (isset($item->verify_hash)) ? $item->verify_hash : null;
         $this->successfulTests = (isset($item->successful_jobs_count)) ? $item->successful_jobs_count : null;

--- a/src/LTaaS/Entities/Job.php
+++ b/src/LTaaS/Entities/Job.php
@@ -15,6 +15,11 @@ class Job
     public $testId;
 
     /**
+     * @var string
+     */
+    public $domainId;
+
+    /**
      * string
      */
     public $crdName;
@@ -91,6 +96,7 @@ class Job
 
         $this->id = $item->id;
         $this->testId = isset($item->test_id) ? $item->test_id : null;
+        $this->domainId = isset($item->domain_id) ? $item->domain_id : null;
         $this->scheduledTimestamp = $item->scheduled_timestamp;
         $this->runNow = (isset($item->run_now)) ? $item->run_now : null;
         $this->crdName = (isset($item->crd_name)) ? $item->crd_name : null;

--- a/src/LTaaS/Entities/Test.php
+++ b/src/LTaaS/Entities/Test.php
@@ -90,6 +90,11 @@ class Test
     public $thresholds;
 
     /**
+     * @var array
+     */
+    public $authorisation;
+
+    /**
      * Test constructor.
      * @param null $item
      */
@@ -115,6 +120,7 @@ class Test
         $this->sectionUsers = (isset($item->sectionUsers)) ? $item->sectionUsers : null;
         $this->sectionTime = (isset($item->sectionTime)) ? $item->sectionTime : null;
         $this->thresholds = (isset($item->thresholds)) ? $item->thresholds : null;
+        $this->authorisation = (isset($item->authorisation)) ? $item->authorisation : null;
 
         if (isset($item->domain)) {
             $this->domainId = $item->domain->id;

--- a/src/LTaaS/Entities/TestAuthorisation.php
+++ b/src/LTaaS/Entities/TestAuthorisation.php
@@ -17,7 +17,7 @@ class TestAuthorisation
     /**
      * @var string
      */
-    public $agreementId;
+    public $agreementVersion;
 
     /**
      * @var string
@@ -47,7 +47,7 @@ class TestAuthorisation
 
         $this->id = $item->id;
         $this->testId = (isset($item->test_id)) ? $item->test_id : null;
-        $this->agreementId = $item->agreement_id;
+        $this->agreementVersion = $item->agreement_version;
         $this->name = $item->name;
         $this->position = $item->position;
         $this->company = (isset($item->position)) ? $item->position : null;

--- a/src/LTaaS/Entities/TestAuthorisation.php
+++ b/src/LTaaS/Entities/TestAuthorisation.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace UKFast\SDK\LTaaS\Entities;
+
+class TestAuthorisation
+{
+    /**
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @var string
+     */
+    public $testId;
+
+    /**
+     * @var string
+     */
+    public $agreementId;
+
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var string
+     */
+    public $position;
+
+    /**
+     * @var string
+     */
+    public $company;
+
+    /**
+     * @var string
+     */
+    public $createdAt;
+
+    public function __construct($item = null)
+    {
+        if (is_null($item)) {
+            return;
+        }
+
+        $this->id = $item->id;
+        $this->testId = (isset($item->test_id)) ? $item->test_id : null;
+        $this->agreementId = $item->agreement_id;
+        $this->name = $item->name;
+        $this->position = $item->position;
+        $this->company = (isset($item->position)) ? $item->position : null;
+        $this->createdAt = $item->created_at;
+    }
+}

--- a/src/LTaaS/JobClient.php
+++ b/src/LTaaS/JobClient.php
@@ -72,6 +72,7 @@ class JobClient extends Client
     {
         $data = [
             'test_id' => $job->testId,
+            'domain_id' => $job->domainId,
             'scheduled_timestamp' => $job->scheduledTimestamp,
             'run_now' => $job->runNow
         ];
@@ -81,7 +82,11 @@ class JobClient extends Client
         $body = $this->decodeJson($response->getBody()->getContents());
 
 
-        return $body->data;
+        return (new SelfResponse($body))
+            ->setClient($this)
+            ->serializeWith(function ($body) {
+                return $this->serializeRequest($body->data);
+            });
     }
 
     /**

--- a/src/LTaaS/JobClient.php
+++ b/src/LTaaS/JobClient.php
@@ -6,6 +6,7 @@ use UKFast\SDK\LTaaS\Entities\JobResults;
 use UKFast\SDK\LTaaS\Entities\JobSettings;
 use UKFast\SDK\Page;
 use UKFast\SDK\LTaaS\Entities\Job;
+use UKFast\SDK\SelfResponse;
 
 class JobClient extends Client
 {
@@ -80,7 +81,7 @@ class JobClient extends Client
         $body = $this->decodeJson($response->getBody()->getContents());
 
 
-        return new Job($body->data);
+        return $body->data;
     }
 
     /**

--- a/src/LTaaS/TestClient.php
+++ b/src/LTaaS/TestClient.php
@@ -5,6 +5,7 @@ namespace UKFast\SDK\LTaaS;
 use UKFast\SDK\LTaaS\Entities\TestAuthorisation;
 use UKFast\SDK\Page;
 use UKFast\SDK\LTaaS\Entities\Test;
+use UKFast\SDK\SelfResponse;
 
 class TestClient extends Client
 {
@@ -37,8 +38,6 @@ class TestClient extends Client
      */
     public function create(Test $test, TestAuthorisation $authorisation)
     {
-//        dd($test->name);
-
         $data = [
             'name' => $test->name,
             'scenario_id' => $test->scenarioId,
@@ -65,7 +64,11 @@ class TestClient extends Client
 
         $body = $this->decodeJson($response->getBody()->getContents());
 
-        return new Test($body->data);
+        return (new SelfResponse($body))
+            ->setClient($this)
+            ->serializeWith(function ($body) {
+                return $this->serializeRequest($body->data);
+            });
     }
 
     /**

--- a/src/LTaaS/TestClient.php
+++ b/src/LTaaS/TestClient.php
@@ -53,7 +53,7 @@ class TestClient extends Client
             'next_run' => $test->nextRun,
             'thresholds' => $test->thresholds,
             'authorisation' => [
-                'agreement_id' => $authorisation->agreementId,
+                'agreement_version' => $authorisation->agreementVersion,
                 'name' => $authorisation->name,
                 'position' => $authorisation->position,
                 'company' => $authorisation->company

--- a/src/LTaaS/TestClient.php
+++ b/src/LTaaS/TestClient.php
@@ -2,6 +2,7 @@
 
 namespace UKFast\SDK\LTaaS;
 
+use UKFast\SDK\LTaaS\Entities\TestAuthorisation;
 use UKFast\SDK\Page;
 use UKFast\SDK\LTaaS\Entities\Test;
 
@@ -30,16 +31,19 @@ class TestClient extends Client
     /**
      * Send the request to the API to store a new test
      * @param Test $test
+     * @param TestAuthorisation $authorisation
      * @return mixed
-     * @throws GuzzleException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    public function create(Test $test)
+    public function create(Test $test, TestAuthorisation $authorisation)
     {
+//        dd($test->name);
+
         $data = [
             'name' => $test->name,
             'scenario_id' => $test->scenarioId,
             'domain_id' => $test->domainId,
+            'protocol' => $test->protocol,
             'path' => $test->path,
             'number_of_users' => $test->numberUsers,
             'duration' => $test->duration,
@@ -48,7 +52,13 @@ class TestClient extends Client
             'section_users' => $test->sectionUsers,
             'section_time' => $test->sectionTime,
             'next_run' => $test->nextRun,
-            'thresholds' => $test->thresholds
+            'thresholds' => $test->thresholds,
+            'authorisation' => [
+                'agreement_id' => $authorisation->agreementId,
+                'name' => $authorisation->name,
+                'position' => $authorisation->position,
+                'company' => $authorisation->company
+            ]
         ];
 
         $response = $this->post('v1/tests', json_encode($data));


### PR DESCRIPTION
Create the Entites that are required for a test to be authorised on creation. Also alter the returned data for the create methods on a test and job to use SelfResponse.