### PR TITLE
Update agreement to pass in the type as a parameter

### DIFF
--- a/src/LTaaS/AgreementClient.php
+++ b/src/LTaaS/AgreementClient.php
@@ -4,7 +4,6 @@ namespace UKFast\SDK\LTaaS;
 
 use GuzzleHttp\Exception\GuzzleException;
 use UKFast\SDK\LTaaS\Entities\Agreement;
-use UKFast\SDK\Page;
 
 class AgreementClient extends Client
 {
@@ -12,12 +11,13 @@ class AgreementClient extends Client
 
     /**
      * Get the latest authorisation agreement
+     * @param $type
      * @return Agreement
      * @throws GuzzleException
      */
-    public function latest()
+    public function latestByType($type)
     {
-        $response = $this->get('v1/agreements/latest');
+        $response = $this->get('v1/agreements/latest/' . $type);
 
         $body = $this->decodeJson($response->getBody()->getContents());
 

--- a/tests/Ltaas/AgreementTest.php
+++ b/tests/Ltaas/AgreementTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Ltaas;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+class AgreementTest extends TestCase
+{
+    /**
+     * @test
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function valid_agreement_request()
+    {
+        $agreementHtml = '<p><<<COMPANY_NAME>>> grants permission to UKFast.Net Limited (“UKFast”) to perform 
+                        load testing as set out below</p><p><strong>Schedule of Test / Domain Details</strong></p>
+                        <p><strong>Test target:</strong> <<<TARGET>>></p>';
+
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                'data' => [
+                    'version' => 'v1.0',
+                    'agreement' => $agreementHtml
+                ],
+                'meta' => []
+            ]))
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $guzzle = new \GuzzleHttp\Client(['handler' => $handler]);
+
+        $client = new \UKFast\SDK\LTaaS\Client($guzzle);
+        $agreement = $client->agreements()->latestByType('single');
+
+        $this->assertTrue($agreement instanceof \UKFast\SDK\LTaaS\Entities\Agreement);
+        $this->assertEquals('v1.0', $agreement->version);
+        $this->assertEquals($agreementHtml, $agreement->agreement);
+    }
+}


### PR DESCRIPTION
Changed the method name from latest to latestByType and added in the parameter $type to the method.