### PR TITLE
Can now pass urls with query strings to PaginationUrl

### DIFF
--- a/src/PaginationUrl.php
+++ b/src/PaginationUrl.php
@@ -26,11 +26,13 @@ class PaginationUrl
         if (substr($path, -1) === "/") {
             $path = substr($path, 0, strlen($path) - 1);
         }
-        if (strpos($path, "?") === false) {
-            $path .= "?";
+
+        $startQuery = "?";
+        if (strpos($path, "?") !== false) {
+            $startQuery = "&";
         }
 
-        $path .= "page=".urlencode($this->page);
+        $path .= "{$startQuery}page=".urlencode($this->page);
         $path .= "&per_page=".urlencode($this->perPage);
 
         foreach ($this->filters as $prop => $filter) {

--- a/tests/PaginationUrlTest.php
+++ b/tests/PaginationUrlTest.php
@@ -60,4 +60,13 @@ class PaginationUrlTest extends TestCase
         $url = new PaginationUrl("/my-endpoint", 1, 10, ['archived' => true]);
         $this->assertEquals("/my-endpoint?page=1&per_page=10&archived=true", $url->toString());
     }
+
+    /**
+     * @test
+     */
+    public function starts_query_with_ampersand_if_a_query_string_is_already_present()
+    {
+        $url = new PaginationUrl("/my-endpoint?some-query-string=present", 1, 10);
+        $this->assertEquals("/my-endpoint?some-query-string=present&page=1&per_page=10", $url->toString());
+    }
 }


### PR DESCRIPTION
Previously, if you passed a url that already had a query parameter in it, it would incorrectly mangle the page query params onto it, e.g.

`my-enpdoint?param=here` would output `my-enpdoint?param=herepage=1&per_page=10`

This change checks if there is a query param present already and handles it appropriately