### PR TITLE
Now sets the invalid json string as the invalid json exception message

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -226,7 +226,7 @@ class Client
         $decoded = json_decode($raw);
         $err = json_last_error();
         if ($err !== JSON_ERROR_NONE) {
-            throw new InvalidJsonException($err);
+            throw new InvalidJsonException($raw);
         }
 
         return $decoded;

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -13,10 +13,11 @@ class ApiException extends UKFastException
     public function __construct($response)
     {
         $response->getBody()->rewind();
-        $body = json_decode($response->getBody()->getContents());
+        $raw = $response->getBody()->getContents();
+        $body = json_decode($raw);
         $err = json_last_error();
         if ($err !== JSON_ERROR_NONE) {
-            throw new InvalidJsonException($err);
+            throw new InvalidJsonException($raw);
         }
 
         if (isset($body->errors) && is_array($body->errors)) {

--- a/src/Page.php
+++ b/src/Page.php
@@ -243,11 +243,12 @@ class Page
      */
     private function constructNewPage($response, $uri)
     {
-        $body = json_decode($response->getBody()->getContents());
+        $raw = $response->getBody()->getContents();
+        $body = json_decode($raw);
 
         $err = json_last_error();
         if ($err !== JSON_ERROR_NONE) {
-            throw new InvalidJsonException($err);
+            throw new InvalidJsonException($raw);
         }
 
         $next = new static($body->data, $body->meta, new Request("GET", $uri));


### PR DESCRIPTION
## Changes

I've updated the InvalidJsonExceptions to accept the invalid json body as the message. This'll give more helpful error messages than '4'