### PR TITLE
Update InvoiceQuery endpoint

### DIFF
--- a/src/Account/InvoiceQueryClient.php
+++ b/src/Account/InvoiceQueryClient.php
@@ -20,7 +20,7 @@ class InvoiceQueryClient extends BaseClient
      */
     public function getById($id)
     {
-        $response = $this->request("GET", "v1/invoices/query/$id");
+        $response = $this->request("GET", "v1/invoice-queries/$id");
         $body = $this->decodeJson($response->getBody()->getContents());
         return new InvoiceQuery($body->data);
     }


### PR DESCRIPTION
We changed the endpoint from `/invoices/query/{id}` to `/invoice-queries/{id}`.

This PR reflects this in our SDK.