### PR TITLE
Delete headers

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -189,6 +189,9 @@ class Client
      */
     public function delete($endpoint, $body = null, $headers = [])
     {
+        $headers = array_merge([
+            'Content-Type'=>'application/json'
+        ], $headers);
         return $this->request('DELETE', $endpoint, $body, $headers);
     }
 


### PR DESCRIPTION
A body is allowed in HTTP DELETE, we're missing adding the header in the client convenience method