### PR TITLE
Add getPage method and resolution properties for Invoice Queries

### DIFF
--- a/src/Account/Entities/InvoiceQuery.php
+++ b/src/Account/Entities/InvoiceQuery.php
@@ -2,6 +2,8 @@
 
 namespace UKFast\SDK\Account\Entities;
 
+use DateTime;
+
 class InvoiceQuery
 {
     /**
@@ -45,6 +47,21 @@ class InvoiceQuery
     public $contactMethod;
 
     /**
+     * @var string
+     */
+    public $resolution;
+
+    /**
+     * @var \DateTime
+     */
+    public $resolutionDate;
+
+    /**
+     * @var string
+     */
+    public $status;
+
+    /**
      * InvoiceQuery constructor.
      *
      * @param null $item
@@ -55,6 +72,10 @@ class InvoiceQuery
             return;
         }
 
+        $resolutionDate = ($item->resolution_date != null)
+            ? DateTime::createFromFormat(DateTime::ISO8601, $item->resolution_date)
+            : null;
+
         $this->id = $item->id;
         $this->contactId = $item->contact_id;
         $this->amount = $item->amount;
@@ -63,5 +84,8 @@ class InvoiceQuery
         $this->proposedSolution = $item->proposed_solution;
         $this->invoiceIds = $item->invoice_ids;
         $this->contactMethod = $item->contact_method;
+        $this->resolution = $item->resolution;
+        $this->resolutionDate = $resolutionDate;
+        $this->status = $item->status;
     }
 }

--- a/src/Account/InvoiceQueryClient.php
+++ b/src/Account/InvoiceQueryClient.php
@@ -83,10 +83,7 @@ class InvoiceQueryClient extends BaseClient
             'what_was_received' => $invoiceQuery->whatWasReceived,
             'proposed_solution' => $invoiceQuery->proposedSolution,
             'invoice_ids' => $invoiceQuery->invoiceIds,
-            'contact_method' => $invoiceQuery->contactMethod,
-            'resolution' => $invoiceQuery->resolution,
-            'resolution_date' => $invoiceQuery->resolutionDate,
-            'status' => $invoiceQuery->status
+            'contact_method' => $invoiceQuery->contactMethod
         ];
 
         return json_encode($payload);

--- a/src/Account/InvoiceQueryClient.php
+++ b/src/Account/InvoiceQueryClient.php
@@ -12,6 +12,25 @@ class InvoiceQueryClient extends BaseClient
     protected $basePath = 'account/';
 
     /**
+     * Gets a paginated response of all invoice queries
+     *
+     * @param int $page
+     * @param int $perPage
+     * @param array $filters
+     * @return Page
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getPage($page = 1, $perPage = 15, $filters = [])
+    {
+        $page = $this->paginatedRequest('v1/invoice-queries', $page, $perPage, $filters);
+        $page->serializeWith(function ($item) {
+            return new InvoiceQuery($item);
+        });
+
+        return $page;
+    }
+
+    /**
      * Gets an individual invoice query
      *
      * @param string $id
@@ -65,6 +84,9 @@ class InvoiceQueryClient extends BaseClient
             'proposed_solution' => $invoiceQuery->proposedSolution,
             'invoice_ids' => $invoiceQuery->invoiceIds,
             'contact_method' => $invoiceQuery->contactMethod,
+            'resolution' => $invoiceQuery->resolution,
+            'resolution_date' => $invoiceQuery->resolutionDate,
+            'status' => $invoiceQuery->status
         ];
 
         return json_encode($payload);

--- a/tests/Account/InvoiceQueryTest.php
+++ b/tests/Account/InvoiceQueryTest.php
@@ -32,7 +32,10 @@ class InvoiceQueryTest extends TestCase
                             2456789,
                             1245678
                     ],
-                    "contact_method" => "email"
+                    "contact_method" => "email",
+                    "resolution" => "This issue was resolved.",
+                    "resolution_date" => '2019-10-25T00:00:00+01:00',
+                    "status" => "Submitted"
                 ],
                 "meta" => []
             ])),
@@ -55,6 +58,9 @@ class InvoiceQueryTest extends TestCase
         $this->assertEquals("Resolve the difference", $invoiceQuery->proposedSolution);
         $this->assertEquals([2514571, 2456789, 1245678], $invoiceQuery->invoiceIds);
         $this->assertEquals("email", $invoiceQuery->contactMethod);
+        $this->assertEquals("This issue was resolved.", $invoiceQuery->resolution);
+        $this->assertInstanceOf(DateTime::class, $invoiceQuery->resolutionDate);
+        $this->assertEquals("Submitted", $invoiceQuery->status);
     }
 
     /**
@@ -67,13 +73,13 @@ class InvoiceQueryTest extends TestCase
                 'id' => 123
             ],
             'meta' => (object) [
-                'location' => 'https://api.ukfast.io/account/v1/invoices/query/123'
+                'location' => 'https://api.ukfast.io/account/v1/invoice-queries/123'
             ],
         ];
 
         $selfResponse = new SelfResponse($response);
 
         $this->assertEquals(123, $selfResponse->getId());
-        $this->assertEquals('https://api.ukfast.io/account/v1/invoices/query/123', $selfResponse->getLocation());
+        $this->assertEquals('https://api.ukfast.io/account/v1/invoice-queries/123', $selfResponse->getLocation());
     }
 }


### PR DESCRIPTION
This MR adds the `getPage` method to the `InvoiceQueryClient`.

It also adds extra properties for Invoice Queries - namely the resolution information, the resolution date, and the status of the query.