### PR TITLE
Add php73 to TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - '5.6'
   - '7.1'
   - '7.2'
+  - '7.3'
 
 cache:
  directories:


### PR DESCRIPTION
We need to add PHP 7.3 to the TravisCI config so our PRs are tested against all the version they are likely to be used with.