### PR TITLE
Add DDoSX Verification Methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",
-        "squizlabs/php_codesniffer": "3.*"
+        "squizlabs/php_codesniffer": "3.*",
+        "fzaninotto/faker": "^1.4"
     }
 }

--- a/src/DDoSX/Client.php
+++ b/src/DDoSX/Client.php
@@ -7,6 +7,11 @@ use UKFast\SDK\Client as BaseClient;
 class Client extends BaseClient
 {
     /**
+     * @inheritDoc
+     */
+    protected $basePath = 'ddosx/';
+
+    /**
      * Return a domainClient instance
      *
      * @return DomainClient
@@ -14,5 +19,15 @@ class Client extends BaseClient
     public function domains()
     {
         return (new DomainClient($this->httpClient))->auth($this->token);
+    }
+
+    /**
+     * Return a DomainVerificationClient instance
+     *
+     * @return DomainVerificationClient
+     */
+    public function domainVerification()
+    {
+        return (new DomainVerificationClient($this->httpClient))->auth($this->token);
     }
 }

--- a/src/DDoSX/DomainVerificationClient.php
+++ b/src/DDoSX/DomainVerificationClient.php
@@ -49,9 +49,8 @@ class DomainVerificationClient extends BaseClient
      */
     public function getVerificationFile($domainName)
     {
-
-        return new VerificationFile(
-            $this->get('v1/domains/' . $domainName . '/verify/file-upload')
-        );
+        return new VerificationFile([
+            'response' => $this->get('v1/domains/' . $domainName . '/verify/file-upload')
+        ]);
     }
 }

--- a/src/DDoSX/DomainVerificationClient.php
+++ b/src/DDoSX/DomainVerificationClient.php
@@ -13,7 +13,8 @@ class DomainVerificationClient extends BaseClient
     protected $basePath = 'ddosx/';
 
     /**
-     * Verify the domain
+     * Verify the domain via DNS
+     *
      * @param $domainName
      * @return boolean
      * @throws \GuzzleHttp\Exception\GuzzleException
@@ -26,7 +27,8 @@ class DomainVerificationClient extends BaseClient
     }
 
     /**
-     * Verify the domain
+     * Verify the domain via file upload
+     *
      * @param $domainName
      * @return boolean
      * @throws \GuzzleHttp\Exception\GuzzleException
@@ -39,7 +41,8 @@ class DomainVerificationClient extends BaseClient
     }
 
     /**
-     * Verify the domain
+     * Get the file for file upload verification
+     *
      * @param $domainName
      * @return mixed
      * @throws \GuzzleHttp\Exception\GuzzleException

--- a/src/DDoSX/DomainVerificationClient.php
+++ b/src/DDoSX/DomainVerificationClient.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace UKFast\SDK\DDoSX;
+
+use UKFast\SDK\Client as BaseClient;
+use UKFast\SDK\DDoSX\Entities\VerificationFile;
+
+class DomainVerificationClient extends BaseClient
+{
+    /**
+     * @inheritDoc
+     */
+    protected $basePath = 'ddosx/';
+
+    /**
+     * Verify the domain
+     * @param $domainName
+     * @return boolean
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function verifyByDns($domainName)
+    {
+        $response = $this->post('v1/domains/' . $domainName . '/verify/dns');
+
+        return $response->getStatusCode() == 200;
+    }
+
+    /**
+     * Verify the domain
+     * @param $domainName
+     * @return boolean
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function verifyByFile($domainName)
+    {
+        $response = $this->post('v1/domains/' . $domainName . '/verify/file-upload');
+
+        return $response->getStatusCode() == 200;
+    }
+
+    /**
+     * Verify the domain
+     * @param $domainName
+     * @return mixed
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getVerificationFile($domainName)
+    {
+
+        return new VerificationFile(
+            $this->get('v1/domains/' . $domainName . '/verify/file-upload')
+        );
+    }
+}

--- a/src/DDoSX/Entities/VerificationFile.php
+++ b/src/DDoSX/Entities/VerificationFile.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace UKFast\SDK\DDoSX\Entities;
+
+use UKFast\SDK\Exception\UKFastException;
+
+class VerificationFile
+{
+    /**
+     * @var \GuzzleHttp\Psr7\Response
+     */
+    protected $response;
+
+    /**
+     * VerificationFile constructor.
+     * @param \GuzzleHttp\Psr7\Response $response
+     */
+    public function __construct($response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * Get a stream of the verification file's body
+     *
+     * @return \GuzzleHttp\Psr7\Stream
+     */
+    public function getStream()
+    {
+        return $this->response->getBody();
+    }
+
+    /**
+     * Get the verification file's name
+     *
+     * @return string
+     * @throws \UKFast\SDK\Exception\UKFastException
+     */
+    public function getName()
+    {
+        $filenameMatch = preg_match('/filename="([[:alnum:]]+\.[[:alnum:]]+)"/', $this->response->getHeaders()['Content-Disposition'][0], $filename);
+
+        if ($filenameMatch === false || empty($filename[1])) {
+            throw new UKFastException('Invalid filename');
+        }
+        return $filename[1];
+    }
+}

--- a/src/DDoSX/Entities/VerificationFile.php
+++ b/src/DDoSX/Entities/VerificationFile.php
@@ -28,7 +28,8 @@ class VerificationFile extends Entity
      */
     public function getName()
     {
-        $filenameMatch = preg_match('/filename="([[:alnum:]]+\.[[:alnum:]]+)"/', $this->response->getHeaders()['Content-Disposition'][0], $filename);
+        $contentDisposition = $this->response->getHeaders()['Content-Disposition'][0];
+        $filenameMatch      = preg_match('/filename="([[:alnum:]]+\.[[:alnum:]]+)"/', $contentDisposition, $filename);
 
         if ($filenameMatch === false || empty($filename[1])) {
             throw new UKFastException('Invalid filename');

--- a/src/DDoSX/Entities/VerificationFile.php
+++ b/src/DDoSX/Entities/VerificationFile.php
@@ -35,4 +35,17 @@ class VerificationFile extends Entity
         }
         return $filename[1];
     }
+
+    /**
+     * @return string|boolean
+     */
+    public function getContentType()
+    {
+        $contentType = $this->response->getHeaders()['Content-Type'][0];
+        if (empty($contentType) === false) {
+            return $contentType;
+        }
+
+        return false;
+    }
 }

--- a/src/DDoSX/Entities/VerificationFile.php
+++ b/src/DDoSX/Entities/VerificationFile.php
@@ -2,24 +2,14 @@
 
 namespace UKFast\SDK\DDoSX\Entities;
 
+use UKFast\SDK\Entity;
 use UKFast\SDK\Exception\UKFastException;
 
-class VerificationFile
+/**
+ * @property GuzzleHttp\Psr7\Response $response
+ */
+class VerificationFile extends Entity
 {
-    /**
-     * @var \GuzzleHttp\Psr7\Response
-     */
-    protected $response;
-
-    /**
-     * VerificationFile constructor.
-     * @param \GuzzleHttp\Psr7\Response $response
-     */
-    public function __construct($response)
-    {
-        $this->response = $response;
-    }
-
     /**
      * Get a stream of the verification file's body
      *

--- a/tests/DDoSX/DomainVerificationTest.php
+++ b/tests/DDoSX/DomainVerificationTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\DDoSX;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Faker\Factory as Faker;
+use PHPUnit\Framework\TestCase;
+use UKFast\SDK\DDoSX\DomainVerificationClient;
+use UKFast\SDK\Exception\ValidationException;
+
+class DomainVerificationTest extends TestCase
+{
+    protected $faker;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->faker = Faker::create();
+    }
+
+
+    /**
+     * @test
+     */
+    public function verify_domain_via_dns()
+    {
+        $mock = new MockHandler([
+            new Response(200),
+            new Response(422),
+        ]);
+
+        $guzzle = new Client(['handler' => HandlerStack::create($mock)]);
+        $client = new DomainVerificationClient($guzzle);
+
+        $this->assertTrue($client->verifyByDns($this->faker->domainName));
+
+        $this->expectException(ValidationException::class);
+        $client->verifyByDns($this->faker->domainName);
+    }
+
+    /**
+     * @test
+     */
+    public function verify_domain_via_file_upload()
+    {
+        $mock = new MockHandler([
+            new Response(200),
+            new Response(422),
+        ]);
+
+        $guzzle = new Client(['handler' => HandlerStack::create($mock)]);
+        $client = new DomainVerificationClient($guzzle);
+
+        $this->assertTrue($client->verifyByDns($this->faker->domainName));
+
+        $this->expectException(ValidationException::class);
+        $client->verifyByDns($this->faker->domainName);
+    }
+
+    /**
+     * @test
+     */
+    public function download_verification_file()
+    {
+        $filename           = $this->faker->word . '.txt';
+        $verificationString = $this->faker->word . PHP_EOL . $this->faker->word;
+
+        $mock = new MockHandler([
+            new Response(200, ['Content-Disposition' => 'attachment; filename="'. $filename . '"'], $verificationString),
+        ]);
+
+        $guzzle = new Client(['handler' => HandlerStack::create($mock)]);
+        $client = new DomainVerificationClient($guzzle);
+
+        $verificationFile = $client->getVerificationFile($this->faker->domainName);
+
+        $this->assertEquals($filename, $verificationFile->getName());
+        $this->assertEquals($verificationString, $verificationFile->getStream()->getContents());
+    }
+}

--- a/tests/DDoSX/DomainVerificationTest.php
+++ b/tests/DDoSX/DomainVerificationTest.php
@@ -68,9 +68,13 @@ class DomainVerificationTest extends TestCase
     {
         $filename           = $this->faker->word . '.txt';
         $verificationString = $this->faker->word . PHP_EOL . $this->faker->word;
+        $contentType        = 'text/plain';
 
         $mock = new MockHandler([
-            new Response(200, ['Content-Disposition' => 'attachment; filename="'. $filename . '"'], $verificationString),
+            new Response(200, [
+                'Content-Disposition' => 'attachment; filename="'. $filename . '"',
+                'Content-Type'        => $contentType,
+            ], $verificationString),
         ]);
 
         $guzzle = new Client(['handler' => HandlerStack::create($mock)]);
@@ -80,5 +84,6 @@ class DomainVerificationTest extends TestCase
 
         $this->assertEquals($filename, $verificationFile->getName());
         $this->assertEquals($verificationString, $verificationFile->getStream()->getContents());
+        $this->assertEquals($contentType, $verificationFile->getContentType());
     }
 }

--- a/tests/DDoSX/DomainVerificationTest.php
+++ b/tests/DDoSX/DomainVerificationTest.php
@@ -28,12 +28,13 @@ class DomainVerificationTest extends TestCase
      */
     public function verify_domain_via_dns()
     {
-        $mock = new MockHandler([
+        $domainName = $this->faker->domainName;
+        $mock       = new MockHandler([
             new Response(200),
             new Response(422, [], json_encode([
                 'errors' => [
                     'title' => '"Verification Failed',
-                    'detail' => 'We were unable to verify phily.ga',
+                    'detail' => 'We were unable to verify ' . $domainName,
                     'status' => 422,
                     'source' => 'domain_name'
                 ]
@@ -43,7 +44,7 @@ class DomainVerificationTest extends TestCase
         $guzzle = new Client(['handler' => HandlerStack::create($mock)]);
         $client = new DomainVerificationClient($guzzle);
 
-        $this->assertTrue($client->verifyByDns($this->faker->domainName));
+        $this->assertTrue($client->verifyByDns($domainName));
 
         $this->expectException(ValidationException::class);
         $client->verifyByDns($this->faker->domainName);
@@ -54,12 +55,13 @@ class DomainVerificationTest extends TestCase
      */
     public function verify_domain_via_file_upload()
     {
-        $mock = new MockHandler([
+        $domainName = $this->faker->domainName;
+        $mock       = new MockHandler([
             new Response(200),
             new Response(422, [], json_encode([
                 'errors' => [
                     'title' => '"Verification Failed',
-                    'detail' => 'We were unable to verify phily.ga',
+                    'detail' => 'We were unable to verify ' . $domainName,
                     'status' => 422,
                     'source' => 'domain_name'
                 ]
@@ -69,7 +71,7 @@ class DomainVerificationTest extends TestCase
         $guzzle = new Client(['handler' => HandlerStack::create($mock)]);
         $client = new DomainVerificationClient($guzzle);
 
-        $this->assertTrue($client->verifyByDns($this->faker->domainName));
+        $this->assertTrue($client->verifyByDns($domainName));
 
         $this->expectException(ValidationException::class);
         $client->verifyByDns($this->faker->domainName);

--- a/tests/DDoSX/DomainVerificationTest.php
+++ b/tests/DDoSX/DomainVerificationTest.php
@@ -30,7 +30,14 @@ class DomainVerificationTest extends TestCase
     {
         $mock = new MockHandler([
             new Response(200),
-            new Response(422),
+            new Response(422, [], json_encode([
+                'errors' => [
+                    'title' => '"Verification Failed',
+                    'detail' => 'We were unable to verify phily.ga',
+                    'status' => 422,
+                    'source' => 'domain_name'
+                ]
+            ])),
         ]);
 
         $guzzle = new Client(['handler' => HandlerStack::create($mock)]);
@@ -49,7 +56,14 @@ class DomainVerificationTest extends TestCase
     {
         $mock = new MockHandler([
             new Response(200),
-            new Response(422),
+            new Response(422, [], json_encode([
+                'errors' => [
+                    'title' => '"Verification Failed',
+                    'detail' => 'We were unable to verify phily.ga',
+                    'status' => 422,
+                    'source' => 'domain_name'
+                ]
+            ])),
         ]);
 
         $guzzle = new Client(['handler' => HandlerStack::create($mock)]);

--- a/tests/DDoSX/DomainVerificationTest.php
+++ b/tests/DDoSX/DomainVerificationTest.php
@@ -84,7 +84,7 @@ class DomainVerificationTest extends TestCase
     {
         $filename           = $this->faker->word . '.txt';
         $verificationString = $this->faker->word . PHP_EOL . $this->faker->word;
-        $contentType        = 'text/plain';
+        $contentType        = 'text/plain; charset=UTF-8';
 
         $mock = new MockHandler([
             new Response(200, [


### PR DESCRIPTION
I would like to verify domains via the SDK, these are the methods which I'll need to do that with.

Testing instructions:

* [ ] `(new DDoSXClient)->domainVerification()->getVerificationFile('mydomain.com');`
* [ ] `(new DDoSXClient)->domainVerification()->verifyByDns('mydomain.com');`
* [ ] `(new DDoSXClient)->domainVerification()->verifyByFile('mydomain.com');`