### PR TITLE
Use Billing Product entity instead of PSS Product entity

### DIFF
--- a/src/Billing/Entities/RecurringCost.php
+++ b/src/Billing/Entities/RecurringCost.php
@@ -4,7 +4,7 @@ namespace UKFast\SDK\Billing\Entities;
 
 use UKFast\SDK\Entity;
 use DateTime;
-use UKFast\SDK\PSS\Entities\Product;
+use UKFast\SDK\Billing\Entities\Product;
 
 /**
  * @property int $id


### PR DESCRIPTION
We currently use the PSS Product entity in Billing but we should use the Billing Product entity to allow us to diverge implementations in the future.