### PR TITLE
Add handler for unsupported date format

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -57,6 +57,9 @@ abstract class Entity
             if (!$datetime) {
                 $datetime = DateTime::createFromFormat('Y-m-d', $value);
             }
+            if (!$datetime) {
+                $datetime = null;
+            }
 
             $value = $datetime;
         }


### PR DESCRIPTION
We would be able to perform an null check on the value, rather that it erroring or returning `false`, which is less useful.