### PR TITLE
Add BaseClient alias to CloudCostClient extension

### DIFF
--- a/src/Billing/CloudCostClient.php
+++ b/src/Billing/CloudCostClient.php
@@ -4,10 +4,9 @@ namespace UKFast\SDK\Billing;
 
 use UKFast\SDK\Billing\Entities\CloudCost;
 use UKFast\SDK\Billing\Entities\Resource;
-use UKFast\SDK\Client;
-use UKFast\SDK\Exception\NotFoundException;
+use UKFast\SDK\Client as BaseClient;
 
-class CloudCostClient extends Client
+class CloudCostClient extends BaseClient
 {
     protected $basePath = 'billing/';
 


### PR DESCRIPTION
This fixes the following error:

```
Cannot use UKFast\SDK\Client as Client because the name is already in use
--
in CloudCostClient.php line 7
```