### PR TITLE
Remove date formatting from validFrom/expiry

### DIFF
--- a/src/Billing/Entities/PaymentCard.php
+++ b/src/Billing/Entities/PaymentCard.php
@@ -24,7 +24,7 @@ class PaymentCard extends Entity
 
     public function isExpired()
     {
-        return new DateTime($this->expiry) < new DateTime();
+        return DateTime::createFromFormat('m/y', $this->expiry) < new DateTime();
     }
 
     public function isNotExpired()

--- a/src/Billing/Entities/PaymentCard.php
+++ b/src/Billing/Entities/PaymentCard.php
@@ -13,8 +13,8 @@ use DateTime;
  * @property string $postcode
  * @property string $cardNumber
  * @property string $cardType
- * @property DateTime $validFrom
- * @property DateTime $expiry
+ * @property string $validFrom
+ * @property string $expiry
  * @property int $issueNumber
  * @property boolean $primaryCard
  */

--- a/src/Billing/Entities/PaymentCard.php
+++ b/src/Billing/Entities/PaymentCard.php
@@ -28,9 +28,10 @@ class PaymentCard extends Entity
      */
     public function isExpired()
     {
-        $date = DateTime::createFromFormat('m/y', $this->expiry);
+        $date = DateTime::createFromFormat('m/y H:i:s', $this->expiry . ' 23:59:59');
+        $input = new DateTime($date->format('Y-m-t H:i:s'));
 
-        return $date->format('Y-m-t') < (new DateTime())->format('Y-m-d');
+        return $input < new DateTime();
     }
 
     /**

--- a/src/Billing/Entities/PaymentCard.php
+++ b/src/Billing/Entities/PaymentCard.php
@@ -20,11 +20,11 @@ use DateTime;
  */
 class PaymentCard extends Entity
 {
-    protected $dates = ['validFrom', 'expiry'];
+    protected $dates = [];
 
     public function isExpired()
     {
-        return $this->expiry < new DateTime();
+        return new DateTime($this->expiry) < new DateTime();
     }
 
     public function isNotExpired()

--- a/src/Billing/Entities/PaymentCard.php
+++ b/src/Billing/Entities/PaymentCard.php
@@ -20,13 +20,25 @@ use DateTime;
  */
 class PaymentCard extends Entity
 {
-    protected $dates = [];
-
+    /**
+     * Check if the PaymentCard has expired.
+     *
+     * @return bool
+     * @throws \Exception
+     */
     public function isExpired()
     {
-        return DateTime::createFromFormat('m/y', $this->expiry) < new DateTime();
+        $date = DateTime::createFromFormat('m/y', $this->expiry);
+
+        return $date->format('Y-m-t') < (new DateTime())->format('Y-m-d');
     }
 
+    /**
+     * Check if the PaymentCard has not yet expired.
+     *
+     * @return bool
+     * @throws \Exception
+     */
     public function isNotExpired()
     {
         return !$this->isExpired();

--- a/tests/Billing/PaymentCardClientTest.php
+++ b/tests/Billing/PaymentCardClientTest.php
@@ -14,6 +14,7 @@ class PaymentCardClientTest extends TestCase
 {
     /**
      * @test
+     * @throws \Exception
      */
     public function get_payment_cards_by_id()
     {
@@ -50,8 +51,8 @@ class PaymentCardClientTest extends TestCase
         $this->assertEquals("M44 0AB", $paymentCard->postcode);
         $this->assertEquals("4111111111111111", $paymentCard->cardNumber);
         $this->assertEquals("Visa", $paymentCard->cardType);
-        $this->assertEquals('2019-10-31T00:00:00+0000', $paymentCard->validFrom->format(DateTime::ISO8601));
-        $this->assertEquals('2035-10-31T00:00:00+0000', $paymentCard->expiry->format(DateTime::ISO8601));
+        $this->assertEquals('2019-10-31T00:00:00+0000', (new DateTime($paymentCard->validFrom))->format(DateTime::ISO8601));
+        $this->assertEquals('2035-10-31T00:00:00+0000', (new DateTime($paymentCard->expiry))->format(DateTime::ISO8601));
         $this->assertEquals(12, $paymentCard->issueNumber);
         $this->assertTrue(true, $paymentCard->primaryCard);
 

--- a/tests/Billing/PaymentCardClientTest.php
+++ b/tests/Billing/PaymentCardClientTest.php
@@ -28,8 +28,8 @@ class PaymentCardClientTest extends TestCase
                     "postcode" => "M44 0AB",
                     "card_number" => "4111111111111111",
                     "card_type" => "Visa",
-                    "valid_from" => "2019-10-31T00:00:00+0000",
-                    "expiry" => "2035-10-31T00:00:00+0000",
+                    "valid_from" => "10/19",
+                    "expiry" => "10/35",
                     "issue_number" => 12,
                     "primary_card" => true
                 ],
@@ -51,8 +51,8 @@ class PaymentCardClientTest extends TestCase
         $this->assertEquals("M44 0AB", $paymentCard->postcode);
         $this->assertEquals("4111111111111111", $paymentCard->cardNumber);
         $this->assertEquals("Visa", $paymentCard->cardType);
-        $this->assertEquals('2019-10-31T00:00:00+0000', (new DateTime($paymentCard->validFrom))->format(DateTime::ISO8601));
-        $this->assertEquals('2035-10-31T00:00:00+0000', (new DateTime($paymentCard->expiry))->format(DateTime::ISO8601));
+        $this->assertEquals('10/19', $paymentCard->validFrom);
+        $this->assertEquals('10/35', $paymentCard->expiry);
         $this->assertEquals(12, $paymentCard->issueNumber);
         $this->assertTrue(true, $paymentCard->primaryCard);
 
@@ -76,8 +76,8 @@ class PaymentCardClientTest extends TestCase
                         "postcode" => "M44 0AB",
                         "card_number" => "4111111111111111",
                         "card_type" => "Visa",
-                        "valid_from" => "2019-10-31T00:00:00+0000",
-                        "expiry" => "2035-10-31T00:00:00+0000",
+                        "valid_from" => "10/19",
+                        "expiry" => "10/35",
                         "issue_number" => 12,
                         "primary_card" => true
                     ],
@@ -90,7 +90,7 @@ class PaymentCardClientTest extends TestCase
                         "card_number" => "5355 1234 5678 9012",
                         "card_type" => "Mastercard",
                         "valid_from" => null,
-                        "expiry" => "2035-10-31T00:00:00+0000",
+                        "expiry" => "10/35",
                         "issue_number" => null,
                         "primary_card" => false
                     ],

--- a/tests/Billing/PaymentCardTest.php
+++ b/tests/Billing/PaymentCardTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Billing;
+
+use PHPUnit\Framework\TestCase;
+use UKFast\SDK\Billing\Entities\PaymentCard;
+
+class PaymentCardTest extends TestCase
+{
+    protected $data = [
+        'name' => 'Test User',
+        'address' => 'Test St.',
+        'postcode' => 'M44 0AB',
+        'cardNumber' => '1234 1234 1234 1234',
+        'cardType' => 'VISA',
+        'validFrom' => null,
+        'issueNumber' => null,
+        'primaryCard' => false
+    ];
+
+    /**
+     * @test
+     */
+    public function is_expired_check_rejects_expired_card()
+    {
+        $card = new PaymentCard($this->data);
+        $card->expiry = '12/18';
+
+        $this->assertTrue($card->isExpired());
+        $this->assertFalse($card->isNotExpired());
+    }
+
+    /**
+     * @test
+     */
+    public function is_expired_check_allows_valid_card()
+    {
+        $year = date('y') + 5;
+
+        $card = new PaymentCard($this->data);
+        $card->expiry = '12/'.$year;
+
+        $this->assertFalse($card->isExpired());
+        $this->assertTrue($card->isNotExpired());
+    }
+
+    /**
+     * @test
+     */
+    public function is_expired_check_accepts_current_month()
+    {
+        $month = date('m');
+        $year = date('y') + 5;
+
+        $card = new PaymentCard($this->data);
+        $card->expiry = $month.'/'.$year;
+
+        $this->assertFalse($card->isExpired());
+        $this->assertTrue($card->isNotExpired());
+    }
+}


### PR DESCRIPTION
Remove the automatic date formatting from the validFrom and expiry m/y fields.