### PR TITLE
Update PodClient to load Pod using base Entity

### DIFF
--- a/src/eCloud/Entities/Pod.php
+++ b/src/eCloud/Entities/Pod.php
@@ -2,29 +2,14 @@
 
 namespace UKFast\SDK\eCloud\Entities;
 
-class Pod
+use UKFast\SDK\Entity;
+
+/**
+ * Class Pod
+ * @property int $id Pod ID
+ * @property string $name Pod Name
+ * @services array $services Services available on the pod
+ */
+class Pod extends Entity
 {
-    public $id;
-    public $name;
-    public $services;
-
-    /**
-     * Pod constructor.
-     * @param null $item
-     */
-    public function __construct($item = null)
-    {
-        if (empty($item)) {
-            return;
-        }
-
-        $this->id = $item->id;
-        $this->name = $item->name;
-
-        $this->services = (object) [
-            'public' => $item->services->public,
-            'burst' => $item->services->burst,
-            'appliances' => $item->services->appliances,
-        ];
-    }
 }

--- a/src/eCloud/Entities/Pod.php
+++ b/src/eCloud/Entities/Pod.php
@@ -8,7 +8,7 @@ use UKFast\SDK\Entity;
  * Class Pod
  * @property int $id Pod ID
  * @property string $name Pod Name
- * @services array $services Services available on the pod
+ * @services object $services Services available on the pod
  */
 class Pod extends Entity
 {

--- a/src/eCloud/PodClient.php
+++ b/src/eCloud/PodClient.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace UKFast\SDK\eCloud;
-;
 
 use UKFast\SDK\Entities\ClientEntityInterface;
 use UKFast\SDK\Page;

--- a/src/eCloud/PodClient.php
+++ b/src/eCloud/PodClient.php
@@ -1,15 +1,23 @@
 <?php
 
 namespace UKFast\SDK\eCloud;
+;
 
+use UKFast\SDK\Entities\ClientEntityInterface;
 use UKFast\SDK\Page;
 
 use UKFast\SDK\eCloud\Entities\Appliance;
 use UKFast\SDK\eCloud\Entities\Pod;
 use UKFast\SDK\eCloud\Entities\Template;
 
-class PodClient extends Client
+class PodClient extends Client implements ClientEntityInterface
 {
+    const MAP = [
+        'id' => 'id',
+        'name' => 'name',
+        'services' => 'services'
+    ];
+
     /**
      * Gets a paginated response of Pods
      *
@@ -23,7 +31,7 @@ class PodClient extends Client
     {
         $page = $this->paginatedRequest("v1/pods", $page, $perPage, $filters);
         $page->serializeWith(function ($item) {
-            return new Pod($item);
+            return $this->loadEntity($item);
         });
 
         return $page;
@@ -38,9 +46,8 @@ class PodClient extends Client
      */
     public function getById($id)
     {
-        $response = $this->get("v1/pods/$id");
-        $body = $this->decodeJson($response->getBody()->getContents());
-        return new Pod($body->data);
+        $response = $this->get('v1/pods/' . $id);
+        return $this->loadEntity($this->decodeJson($response->getBody()->getContents())->data);
     }
 
     /**
@@ -96,5 +103,15 @@ class PodClient extends Client
         });
 
         return $page;
+    }
+
+    /**
+     * Load Pod Entity
+     * @param $data
+     * @return mixed|Pod
+     */
+    public function loadEntity($data)
+    {
+        return new Pod($this->apiToFriendly($data, static::MAP));
     }
 }

--- a/tests/eCloud/PodTest.php
+++ b/tests/eCloud/PodTest.php
@@ -10,6 +10,56 @@ use PHPUnit\Framework\TestCase;
 
 class PodTest extends TestCase
 {
+    /**
+     * @test
+     */
+    public function get_pod()
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                'data' => [
+                    'id' => 1,
+                    'name' => 'RnD Cloud',
+                    'services' => [
+                        'public' => true,
+                        'burst' => true,
+                        'appliances' => true,
+                        'gpu' => true,
+                    ]
+                ],
+                "meta" => [
+                    "pagination" => [
+                        "total" => 1,
+                        "count" => 2,
+                        "per_page" => 100,
+                        "current_page" => 1,
+                        "total_pages" => 1,
+                        "links" => []
+                    ]
+                ]
+            ])),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $guzzle = new Guzzle(['handler' => $handler]);
+        $client = new \UKFast\SDK\eCloud\Client($guzzle);
+        $pod = $client->pods()->getById(1);
+
+        $this->assertTrue($pod instanceof \UKFast\SDK\eCloud\Entities\Pod);
+
+        $this->assertEquals(1, $pod->id);
+        $this->assertEquals('RnD Cloud', $pod->name);
+        $this->assertEquals((object) [
+            'public' => true,
+            'burst' => true,
+            'appliances' => true,
+            'gpu' => true,
+        ], $pod->services);
+    }
+
+    /**
+     * @test
+     */
     public function testGetPodAppliances()
     {
         $data = [[


### PR DESCRIPTION
- Updates the PodClient to load the Pod using the base Entity

- Updates PodClient to implement ClientEntityInterface so that we can return the admin version of the pod entity in the admin client.