### PR TITLE
Add InvoiceQuery endpoints to Billing SDK

### DIFF
--- a/src/Billing/Client.php
+++ b/src/Billing/Client.php
@@ -23,4 +23,12 @@ class Client extends BaseClient
     {
         return (new RecurringCostClient($this->httpClient))->auth($this->token);
     }
+
+    /**
+     * @return BaseClient
+     */
+    public function invoiceQueries()
+    {
+        return (new InvoiceQueryClient($this->httpClient))->auth($this->token);
+    }
 }

--- a/src/Billing/Entities/InvoiceQuery.php
+++ b/src/Billing/Entities/InvoiceQuery.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace UKFast\SDK\Billing\Entities;
+
+use UKFast\SDK\Entity;
+
+/**
+ * @property int $id
+ * @property int $contactId
+ * @property float $amount
+ * @property string $whatWasExpected
+ * @property string $whatWasReceived
+ * @property string $proposedSolution
+ * @property string $contactMethod
+ * @property array $invoiceIds
+ * @property string $resolution
+ * @property \DateTime $resolutionDate
+ * @property string $status
+ * @property \DateTime $date
+ */
+class InvoiceQuery extends Entity
+{
+    protected $dates = [
+        'resolutionDate',
+        'date'
+    ];
+}

--- a/src/Billing/InvoiceQueryClient.php
+++ b/src/Billing/InvoiceQueryClient.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace UKFast\SDK\Billing;
+
+use UKFast\SDK\Billing\Entities\InvoiceQuery;
+use UKFast\SDK\Client;
+use UKFast\SDK\SelfResponse;
+
+class InvoiceQueryClient extends Client
+{
+    protected $basePath = 'billing/';
+
+    const MAP = [
+        'contact_id' => 'contactId',
+        'what_was_expected' => 'whatWasExpected',
+        'what_was_received' => 'whatWasReceived',
+        'proposed_solution' => 'proposedSolution',
+        'invoice_ids' => 'invoiceIds',
+        'contact_method' => 'contactMethod',
+        'resolution_date' => 'resolutionDate'
+    ];
+
+    /**
+     * Gets a paginated response of all invoice queries
+     *
+     * @param int $page
+     * @param int $perPage
+     * @param array $filters
+     * @throws \UKFast\SDK\Exception\UKFastException
+     * @return \UKFast\SDK\Page
+     */
+    public function getPage($page = 1, $perPage = 15, $filters = [])
+    {
+        $filters = $this->friendlyToApi($filters, self::MAP);
+        $page = $this->paginatedRequest('v1/invoice-queries', $page, $perPage, $filters);
+        $page->serializeWith(function ($item) {
+            return $this->serializeInvoiceQuery($item);
+        });
+
+        return $page;
+    }
+
+    /**
+     * Gets an individual invoice query
+     *
+     * @param $id
+     * @return InvoiceQuery
+     */
+    public function getById($id)
+    {
+        $response = $this->request("GET", "v1/invoice-queries/$id");
+        $body = $this->decodeJson($response->getBody()->getContents());
+        $item = $body->data;
+
+        return $this->serializeInvoiceQuery($item);
+    }
+
+    /**
+     * Creates a new Invoice Query
+     *
+     * @param $invoiceQuery
+     * @return SelfResponse
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function create($invoiceQuery)
+    {
+        $response = $this->post("v1/invoice-queries", json_encode($this->friendlyToApi($invoiceQuery, self::MAP)));
+        $response = $this->decodeJson($response->getBody()->getContents());
+
+        return (new SelfResponse($response))
+            ->setClient($this)
+            ->serializeWith(function ($response) {
+                return $this->serializeInvoiceQuery($response->data);
+            });
+    }
+
+    protected function serializeInvoiceQuery($raw)
+    {
+        return new InvoiceQuery($this->apiToFriendly($raw, self::MAP));
+    }
+}

--- a/src/Billing/InvoiceQueryClient.php
+++ b/src/Billing/InvoiceQueryClient.php
@@ -3,10 +3,10 @@
 namespace UKFast\SDK\Billing;
 
 use UKFast\SDK\Billing\Entities\InvoiceQuery;
-use UKFast\SDK\Client;
+use UKFast\SDK\Client as BaseClient;
 use UKFast\SDK\SelfResponse;
 
-class InvoiceQueryClient extends Client
+class InvoiceQueryClient extends BaseClient
 {
     protected $basePath = 'billing/';
 

--- a/tests/Billing/InvoiceQueryClientTest.php
+++ b/tests/Billing/InvoiceQueryClientTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Billing;
+
+use DateTime;
+use GuzzleHttp\Client as Guzzle;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use UKFast\SDK\SelfResponse;
+
+class InvoiceQueryClientTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function get_invoice_query_by_id()
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                "data" => [
+                    "id" => 1,
+                    "contact_id" => 1,
+                    "amount" => 5000,
+                    "what_was_expected" => "I didn't get the full amount",
+                    "what_was_received" => "4500",
+                    "proposed_solution" => "Resolve the difference",
+                    "invoice_ids" => [
+                        2514571,
+                        2456789,
+                        1245678
+                    ],
+                    "contact_method" => "email",
+                    "resolution" => "This issue was resolved.",
+                    "resolution_date" => '2019-10-25T00:00:00+01:00',
+                    "status" => "Submitted",
+                    "date" => "2019-11-07T10:56:54+00:00"
+                ],
+                "meta" => []
+            ])),
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $guzzle = new Guzzle(['handler' => $handler]);
+
+        $id = 1;
+
+        $client = new \UKFast\SDK\Billing\Client($guzzle);
+        $invoiceQuery = $client->invoiceQueries()->getById($id);
+
+        $this->assertTrue($invoiceQuery instanceof \UKFast\SDK\Billing\Entities\InvoiceQuery);
+        $this->assertEquals($id, $invoiceQuery->id);
+        $this->assertEquals(1, $invoiceQuery->contactId);
+        $this->assertEquals(5000, $invoiceQuery->amount);
+        $this->assertEquals("I didn't get the full amount", $invoiceQuery->whatWasExpected);
+        $this->assertEquals("4500", $invoiceQuery->whatWasReceived);
+        $this->assertEquals("Resolve the difference", $invoiceQuery->proposedSolution);
+        $this->assertEquals([2514571, 2456789, 1245678], $invoiceQuery->invoiceIds);
+        $this->assertEquals("email", $invoiceQuery->contactMethod);
+        $this->assertEquals("This issue was resolved.", $invoiceQuery->resolution);
+        $this->assertInstanceOf(DateTime::class, $invoiceQuery->resolutionDate);
+        $this->assertEquals("Submitted", $invoiceQuery->status);
+        $this->assertInstanceOf(DateTime::class, $invoiceQuery->date);
+    }
+
+    /**
+     * @test
+     */
+    public function check_self_response_parses_query_response()
+    {
+        $response = (object) [
+            'data' => (object) [
+                'id' => 123
+            ],
+            'meta' => (object) [
+                'location' => 'https://api.ukfast.io/billing/v1/invoice-queries/123'
+            ],
+        ];
+
+        $selfResponse = new SelfResponse($response);
+
+        $this->assertEquals(123, $selfResponse->getId());
+        $this->assertEquals('https://api.ukfast.io/billing/v1/invoice-queries/123', $selfResponse->getLocation());
+    }
+}


### PR DESCRIPTION
This PR adds:

- `getPage()`
- `getById()`
- `create()`