### PR TITLE
Add missing record destroy method

### DIFF
--- a/src/DDoSX/RecordClient.php
+++ b/src/DDoSX/RecordClient.php
@@ -61,18 +61,38 @@ class RecordClient extends BaseClient
         return $page;
     }
 
+    /**
+     * Create a new DDoSX Record
+     *
+     * @param Record $record
+     * @return SelfResponse
+     */
     public function create(Record $record)
     {
         $response = $this->post(
             'v1/domains/' . $record->domainName . '/records',
             json_encode($this->friendlyToApi($record, $this->requestMap))
         );
-        $body     = $this->decodeJson($response->getBody()->getContents());
+        $body = $this->decodeJson($response->getBody()->getContents());
 
         return (new SelfResponse($body))
             ->setClient($this)
             ->serializeWith(function ($body) {
                 return new Record($this->apiToFriendly($body->data, $this->requestMap));
             });
+    }
+
+    /**
+     * Delete an existing DDoSX Record
+     *
+     * @param Record $record
+     * @return bool
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function destroy(Record $record)
+    {
+        $response = $this->delete("v1/domains/".$record->domainName."/records/".$record->id);
+
+        return $response->getStatusCode() == 204;
     }
 }


### PR DESCRIPTION
For https://gitlab.devops.ukfast.co.uk/ukfast/myukfast/myukfast/issues/2644

This merge request adds the `destroy` method for a DDoSX Record. It will be used to allow the user to delete a record using the MyUKFast pages implemented in the issue linked above

## Code Review
- [ ]  Click on the 'Delete' button in the DNS Records list view added to MyUKFast in the above issue.
- [ ]  Observe that the record is successfully deleted.