### PR TITLE
Add getById method to the DDoSX SSL client class

### DIFF
--- a/src/DDoSX/SslClient.php
+++ b/src/DDoSX/SslClient.php
@@ -44,7 +44,7 @@ class SslClient extends BaseClient
 
     /**
      * Gets the SSL by its Id
-     * @param int $sslId
+     * @param string $sslId
      * @return object Ssl
      * @throws \GuzzleHttp\Exception\GuzzleException
      */

--- a/src/DDoSX/SslClient.php
+++ b/src/DDoSX/SslClient.php
@@ -43,6 +43,19 @@ class SslClient extends BaseClient
     }
 
     /**
+     * Gets the SSL by its Id
+     * @param int $sslId
+     * @return object Customer
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getById($sslId)
+    {
+        $response = $this->request("GET", "v1/ssls/$sslId");
+        $body = $this->decodeJson($response->getBody()->getContents());
+        return $this->serializeSsl($body->data);
+    }
+
+    /**
      * Send the request to the API to store a new job
      * @param Ssl $ssl
      * @return SelfResponse

--- a/src/DDoSX/SslClient.php
+++ b/src/DDoSX/SslClient.php
@@ -45,7 +45,7 @@ class SslClient extends BaseClient
     /**
      * Gets the SSL by its Id
      * @param int $sslId
-     * @return object Customer
+     * @return object Ssl
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function getById($sslId)

--- a/tests/DDoSX/SslClientTest.php
+++ b/tests/DDoSX/SslClientTest.php
@@ -127,6 +127,36 @@ class SslClientTest extends TestCase
 
     /**
      * @test
+     * @throws \Exception
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function gets_ssl_by_id()
+    {
+        $uuid = $this->faker->uuid;
+        $mockHandler = new MockHandler([
+            new Response(200, [], json_encode([
+                'data' => [
+                    'id'            => $uuid,
+                    'ukfast_ssl_id' => $this->faker->randomDigit,
+                    'domains'       => [
+                        $this->faker->domainName,
+                        $this->faker->domainName,
+                    ],
+                    'friendly_name' => $this->faker->word,
+                    'expires_at'    => $this->faker->dateTimeBetween('+1 day', '+825 days')->format(DateTime::ATOM),
+                ]
+            ])),
+        ]);
+
+        $httpClient = new GuzzleClient(['handler' => HandlerStack::create($mockHandler)]);
+        $client     = new SslClient($httpClient);
+        $ssl    = $client->getById($uuid);
+
+        $this->assertInstanceOf(Ssl::class, $ssl);
+    }
+
+    /**
+     * @test
      */
     public function creates_and_gets_ssl_correctly()
     {


### PR DESCRIPTION
The getById method has not yet been added to the public client class. Adding it makes the SSL client methods consistent with those available in the other client classes