### PR TITLE
Add DateTime::ATOM format into Entity::set()

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -82,19 +82,9 @@ abstract class Entity implements ArrayAccess
      * @param string $attr
      * @param mixed $value
      * @return void
-     * @throws \Exception
      */
     public function set($attr, $value)
     {
-        if (in_array($attr, array_keys($this->dates))) {
-            try {
-                $datetime = new DateTime($value);
-                $value = $datetime->format($this->dates[$attr]);
-            } catch (\Exception $e) {
-                $datetime = null;
-            }
-        }
-
         if (in_array($attr, $this->dates)) {
             $datetime = DateTime::createFromFormat(DateTime::ATOM, $value);
             if (!$datetime) {

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -82,11 +82,24 @@ abstract class Entity implements ArrayAccess
      * @param string $attr
      * @param mixed $value
      * @return void
+     * @throws \Exception
      */
     public function set($attr, $value)
     {
+        if (in_array($attr, array_keys($this->dates))) {
+            try {
+                $datetime = new DateTime($value);
+                $value = $datetime->format($this->dates[$attr]);
+            } catch (\Exception $e) {
+                $datetime = null;
+            }
+        }
+
         if (in_array($attr, $this->dates)) {
-            $datetime = DateTime::createFromFormat(DateTime::ISO8601, $value);
+            $datetime = DateTime::createFromFormat(DateTime::ATOM, $value);
+            if (!$datetime) {
+                $datetime = DateTime::createFromFormat(DateTime::ISO8601, $value);
+            }
             if (!$datetime) {
                 $datetime = DateTime::createFromFormat('Y-m-d', $value);
             }


### PR DESCRIPTION
This PR adds the `DateTime::ATOM` format into the Entity set method. With a fallback to the current `DateTime::ISO8601` default.