### PR TITLE
hdd attribute renamed to disk

### DIFF
--- a/src/DRaaS/Entities/Replica.php
+++ b/src/DRaaS/Entities/Replica.php
@@ -11,7 +11,7 @@ use UKFast\SDK\Entity;
  * @property string $platform
  * @property integer $cpu
  * @property integer $ram
- * @property integer $hdd
+ * @property integer $disk
  * @property integer $iops
  * @property boolean $power
  */


### PR DESCRIPTION
Following minor spec change the hdd attribute has been renamed to disk to prevent client confusion.

DRAAS#83