### PR TITLE
Support body and headers on paginatedRequest

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -200,6 +200,7 @@ class Client
      * @param int $page
      * @param int $perPage
      * @param array $filters
+     * @param array $headers
      * @throws GuzzleException
      * @return Page
      */

--- a/src/Client.php
+++ b/src/Client.php
@@ -203,11 +203,11 @@ class Client
      * @throws GuzzleException
      * @return Page
      */
-    public function paginatedRequest($endpoint, $page, $perPage, $filters = [], $body = null, $headers = [])
+    public function paginatedRequest($endpoint, $page, $perPage, $filters = [], $headers = [])
     {
         $url = (new PaginationUrl($endpoint, $page, $perPage, $filters))->toString();
 
-        $response = $this->request('GET', $url, $body, $headers);
+        $response = $this->request('GET', $url, null, $headers);
 
         $body = $this->decodeJson($response->getBody()->getContents());
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -203,11 +203,11 @@ class Client
      * @throws GuzzleException
      * @return Page
      */
-    public function paginatedRequest($endpoint, $page, $perPage, $filters = [])
+    public function paginatedRequest($endpoint, $page, $perPage, $filters = [], $body = null, $headers = [])
     {
         $url = (new PaginationUrl($endpoint, $page, $perPage, $filters))->toString();
 
-        $response = $this->request('GET', $url);
+        $response = $this->request('GET', $url, $body = null, $headers = []);
 
         $body = $this->decodeJson($response->getBody()->getContents());
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -207,7 +207,7 @@ class Client
     {
         $url = (new PaginationUrl($endpoint, $page, $perPage, $filters))->toString();
 
-        $response = $this->request('GET', $url, $body = null, $headers = []);
+        $response = $this->request('GET', $url, $body, $headers);
 
         $body = $this->decodeJson($response->getBody()->getContents());
 


### PR DESCRIPTION
At the moment we don't support passing `$body` or `$headers` to the paginatedRequest method even though it's supported properly by the underlying request method.

This PR introduces this functionality with sensible defaults of `null` and `[]` respectively. 