### PR TITLE
Support PHP 8 in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [7.4, 7.3, 7.2, 7.1, 5.6]
+                php: [8.0, 7.4, 7.3, 7.2, 7.1, 5.6]
 
         name: PHP${{ matrix.php }} - ubuntu-latest
 


### PR DESCRIPTION
We currently don't support PHP 8 in our CI workflow.

This PR adds support so we know the SDK works on the latest major version.