### PR TITLE
Threatmon feature request 8 active response blocked dashboards

### DIFF
--- a/src/ThreatMonitoring/Client.php
+++ b/src/ThreatMonitoring/Client.php
@@ -3,13 +3,16 @@
 namespace UKFast\SDK\ThreatMonitoring;
 
 use UKFast\SDK\Client as BaseClient;
+use UKFast\SDK\ThreatMonitoring\Reporting\ActiveResponseClient;
 use UKFast\SDK\ThreatMonitoring\Reporting\AttackGeolocationClient;
+use UKFast\SDK\ThreatMonitoring\Reporting\AttackingCountriesClient;
 use UKFast\SDK\ThreatMonitoring\Reporting\AttackingIpsClient;
 use UKFast\SDK\ThreatMonitoring\Reporting\BlockedAttacksClient;
 use UKFast\SDK\ThreatMonitoring\Reporting\EventsClient;
 use UKFast\SDK\ThreatMonitoring\Reporting\LoginHistoryClient;
 use UKFast\SDK\ThreatMonitoring\Reporting\MissedAttacksClient;
 use UKFast\SDK\ThreatMonitoring\Reporting\TopAlertsClient;
+use UKFast\SDK\ThreatMonitoring\Reporting\TopBruteforceUsernamesClient;
 use UKFast\SDK\ThreatMonitoring\Reporting\TopFilesChangedClient;
 
 class Client extends BaseClient
@@ -118,6 +121,30 @@ class Client extends BaseClient
     public function missedAttacksReports()
     {
         return (new MissedAttacksClient($this->httpClient))->auth($this->token);
+    }
+
+    /**
+     * @return TopBruteforceUsernamesClient
+     */
+    public function topBruteForceUsernamesReports()
+    {
+        return (new TopBruteForceUsernamesClient($this->httpClient))->auth($this->token);
+    }
+
+    /**
+     * @return ActiveResponseClient
+     */
+    public function activeResponseReports()
+    {
+        return (new ActiveResponseClient($this->httpClient))->auth($this->token);
+    }
+
+    /**
+     * @return AttackingCountriesClient
+     */
+    public function attackingCountriesReports()
+    {
+        return (new AttackingCountriesClient($this->httpClient))->auth($this->token);
     }
     
     /**

--- a/src/ThreatMonitoring/Entities/ActiveResponseBlockedAttacks.php
+++ b/src/ThreatMonitoring/Entities/ActiveResponseBlockedAttacks.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace UKFast\SDK\ThreatMonitoring\Entities;
+
+use UKFast\SDK\Entity;
+
+/**
+ * @property integer $total
+ */
+class ActiveResponseBlockedAttacks extends Entity
+{
+}

--- a/src/ThreatMonitoring/Entities/AttackingCountriesList.php
+++ b/src/ThreatMonitoring/Entities/AttackingCountriesList.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace UKFast\SDK\ThreatMonitoring\Entities;
+
+use UKFast\SDK\Entity;
+
+/**
+ * @property string country_name
+ * @property integer count
+ */
+class AttackingCountriesList extends Entity
+{
+}

--- a/src/ThreatMonitoring/Entities/ScaScoreAverage.php
+++ b/src/ThreatMonitoring/Entities/ScaScoreAverage.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace UKFast\SDK\ThreatMonitoring\Entities;
+
+use UKFast\SDK\Entity;
+
+/**
+ * @property float $average
+ */
+class ScaScoreAverage extends Entity
+{
+}

--- a/src/ThreatMonitoring/Entities/TopBruteForceUsernamesList.php
+++ b/src/ThreatMonitoring/Entities/TopBruteForceUsernamesList.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace UKFast\SDK\ThreatMonitoring\Entities;
+
+use UKFast\SDK\Entity;
+
+/**
+ * @property string $usernmae
+ * @property integer $count
+ */
+class TopBruteForceUsernamesList extends Entity
+{
+}

--- a/src/ThreatMonitoring/Reporting/ActiveResponseClient.php
+++ b/src/ThreatMonitoring/Reporting/ActiveResponseClient.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace UKFast\SDK\ThreatMonitoring\Reporting;
+
+use UKFast\SDK\Page;
+use UKFast\SDK\ThreatMonitoring\Client;
+use UKFast\SDK\ThreatMonitoring\Entities\ActiveResponseBlockedAttacks;
+
+class ActiveResponseClient extends Client
+{
+    const ACTIVE_RESPONSE_BLOCKED_ATTACK_LIST_MAP = [
+        'geolocation_ip' => 'ip',
+        'abuseipdb_abuse_confidence_score' => 'abuse_confidence_score',
+    ];
+
+    /**
+     * Get the total number of blocked attacks
+     * @param int $page
+     * @param int $per_page
+     * @param array $filters
+     * @return Page
+     */
+    public function getBlockedAttacksList($page = 1, $per_page = 15, $filters = [])
+    {
+        $page = $this->paginatedRequest('v1/reports/active-response/blocked-attacks', $page, $per_page, $filters);
+
+        $page->serializeWith(function ($item) {
+            return $this->serializeBlockedAttackList($item);
+        });
+
+        return $page;
+    }
+
+    public function serializeBlockedAttackList($data)
+    {
+        $blockedAttack = new ActiveResponseBlockedAttacks($this->apiToFriendly($data, self::ACTIVE_RESPONSE_BLOCKED_ATTACK_LIST_MAP));
+        $blockedAttack->syncOriginalAttributes();
+
+        return $blockedAttack;
+    }
+}

--- a/src/ThreatMonitoring/Reporting/AttackingCountriesClient.php
+++ b/src/ThreatMonitoring/Reporting/AttackingCountriesClient.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace UKFast\SDK\ThreatMonitoring\Reporting;
+
+use UKFast\SDK\ThreatMonitoring\Client;
+use UKFast\SDK\ThreatMonitoring\Entities\AttackingCountriesList;
+
+class AttackingCountriesClient extends Client
+{
+    const ATTACKING_COUNTRIES_TOP_BLOCKED_LIST_MAP = [];
+
+    /**
+     * Get a list of the top most blocked countries
+     * @param array $filters
+     * @return array
+     */
+    public function getTopBlockedList($filters = [])
+    {
+        $queryParams = '';
+
+        if (count($filters) > 0) {
+            $queryParams = '?' . http_build_query($filters);
+        }
+
+        $response = $this->get('v1/reports/attacking-countries/blocked/top' . $queryParams);
+
+        $body = $this->decodeJson($response->getBody()->getContents());
+
+        return array_map(function ($item) {
+            return $this->serializeTopAttackingCountriesList($item);
+        }, $body->data);
+    }
+
+    public function serializeTopAttackingCountriesList($data)
+    {
+        return new AttackingCountriesList($this->apiToFriendly($data, static::ATTACKING_COUNTRIES_TOP_BLOCKED_LIST_MAP));
+    }
+}

--- a/src/ThreatMonitoring/Reporting/AttackingIpsClient.php
+++ b/src/ThreatMonitoring/Reporting/AttackingIpsClient.php
@@ -55,6 +55,70 @@ class AttackingIpsClient extends Client
         }, $body->data);
     }
 
+
+    /**
+     * Get the total number of blocked ip addresses
+     * @param array $filters
+     * @return BlockedAttackingIpsTotal
+     */
+    public function getBlockedTotal($filters = [])
+    {
+        $queryParams = '';
+
+        if (count($filters) > 0) {
+            $queryParams = '?' . http_build_query($filters);
+        }
+
+        $response = $this->get('v1/reports/attacking-ips/blocked/total' . $queryParams);
+
+        $body = $this->decodeJson($response->getBody()->getContents());
+        return $this->serializeAttackingIpTotal($body->data);
+    }
+
+    /**
+     * Get a list of the blocked ips
+     * @param array $filters
+     * @return array
+     */
+    public function getBlockedList($filters = [])
+    {
+        $queryParams = '';
+
+        if (count($filters) > 0) {
+            $queryParams = '?' . http_build_query($filters);
+        }
+
+        $response = $this->get('v1/reports/attacking-ips/blocked/list' . $queryParams);
+
+        $body = $this->decodeJson($response->getBody()->getContents());
+
+        return array_map(function ($item) {
+            return $this->serializeAttackingIpList($item);
+        }, $body->data);
+    }
+
+    /**
+     * Get a list of the top most blocked ips
+     * @param array $filters
+     * @return array
+     */
+    public function getTopBlockedList($filters = [])
+    {
+        $queryParams = '';
+
+        if (count($filters) > 0) {
+            $queryParams = '?' . http_build_query($filters);
+        }
+
+        $response = $this->get('v1/reports/attacking-ips/blocked/top' . $queryParams);
+
+        $body = $this->decodeJson($response->getBody()->getContents());
+
+        return array_map(function ($item) {
+            return $this->serializeAttackingIpList($item);
+        }, $body->data);
+    }
+
     public function serializeAttackingIpTotal($data)
     {
         return new AttackingIpsTotal($this->apiToFriendly($data, static::ATTACKING_IPS_TOTAL_MAP));

--- a/src/ThreatMonitoring/Reporting/ScaClient.php
+++ b/src/ThreatMonitoring/Reporting/ScaClient.php
@@ -5,6 +5,7 @@ namespace UKFast\SDK\ThreatMonitoring\Reporting;
 
 use UKFast\SDK\ThreatMonitoring\Client;
 use UKFast\SDK\ThreatMonitoring\Entities\ScaResults;
+use UKFast\SDK\ThreatMonitoring\Entities\ScaScoreAverage;
 use UKFast\SDK\ThreatMonitoring\Entities\ScaSuggestionResults;
 use UKFast\SDK\ThreatMonitoring\Entities\TopAlertsList;
 use UKFast\SDK\ThreatMonitoring\Entities\TopAlertsType;
@@ -14,6 +15,9 @@ class ScaClient extends Client
     const SUGGESTION_MAP = [];
 
     const INDIVIDUAL_MAP = [];
+
+    const SCA_SCORE_AVERAGE_MAP = [];
+
     /**
      * Get Sca Data
      *
@@ -41,5 +45,31 @@ class ScaClient extends Client
         $response = $this->get('v1/agents/' . $agentId . '/sca/checks/' . $policyId);
         $data = $this->decodeJson($response->getBody()->getContents());
         return new ScaSuggestionResults($this->apiToFriendly($data, self::INDIVIDUAL_MAP));
+    }
+
+    /**
+     * Get average sca scores for agents for a reseller.
+     *
+     * @param array $filters
+     * @return ScaScoreAverage
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function getScaScoreAverage ($filters = []) : ScaScoreAverage
+    {
+        $queryParams = '';
+
+        if (count($filters)) {
+            $queryParams = '?' . http_build_query($filters);
+        }
+
+        $response = $this->get('v1/reports/sca-score/average' . $queryParams);
+
+        $body = $this->decodeJson($response->getBody()->getContents());
+
+        return $this->serializeScaScoreAverage($body->data);
+    }
+
+    public function serializeScaScoreAverage($data) {
+        return new ScaScoreAverage($this->apiToFriendly($data, static::SCA_SCORE_AVERAGE_MAP));
     }
 }

--- a/src/ThreatMonitoring/Reporting/TopBruteForceUsernamesClient.php
+++ b/src/ThreatMonitoring/Reporting/TopBruteForceUsernamesClient.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace UKFast\SDK\ThreatMonitoring\Reporting;
+
+use UKFast\SDK\ThreatMonitoring\Client;
+use UKFast\SDK\ThreatMonitoring\Entities\TopBruteForceUsernamesList;
+
+class TopBruteForceUsernamesClient extends Client
+{
+    const TOP_BRUTE_FORCE_USERNAMES_LIST_MAP = [
+        'source_user' => 'username'
+    ];
+
+    /**
+     * Get the top 10 most commonly used brute force usernames
+     * @param array $filters
+     * @return TopBruteforceUsernamesList
+     */
+    public function getList($filters = [])
+    {
+        $queryParams = '';
+
+        if (count($filters) > 0) {
+            $queryParams = '?' . http_build_query($filters);
+        }
+
+        $response = $this->get('v1/reports/top-brute-force-usernames/list' . $queryParams);
+
+        $body = $this->decodeJson($response->getBody()->getContents());
+        return array_map(function ($item) {
+            return $this->serializeTopBruteForceUsernamesList($item);
+        }, $body->data);
+    }
+
+    public function serializeTopBruteForceUsernamesList($data)
+    {
+        return new TopBruteforceUsernamesList($this->apiToFriendly($data, static::TOP_BRUTE_FORCE_USERNAMES_LIST_MAP));
+    }
+}

--- a/src/eCloud/Entities/Volume.php
+++ b/src/eCloud/Entities/Volume.php
@@ -8,6 +8,7 @@ use UKFast\SDK\Entity;
  * @property string $id
  * @property string $name
  * @property string $vpcId
+ * @property string $availabilityZoneId
  * @property integer $capacity
  * @property integer $iops
  * @property boolean $attached

--- a/src/eCloud/VolumeClient.php
+++ b/src/eCloud/VolumeClient.php
@@ -18,6 +18,7 @@ class VolumeClient extends Client implements ClientEntityInterface
             'id' => 'id',
             'name' => 'name',
             'vpc_id' => 'vpcId',
+            'availability_zone_id' => 'availabilityZoneId',
             'capacity' => 'capacity',
             'iops' => 'iops',
             'attached' => 'attached',


### PR DESCRIPTION
This adds the reporting endpoints for the new Attacks dashboard for Threat Vision,
The new metrics are:

- total blocked attacks,
- list of top attacking countries,
- list of top brute force usernames,
- average SCA score,
- active response blocked attacks list,
- total blocked IPs,
- list of blocked IPs