### PR TITLE
Add map back to listener client

### DIFF
--- a/src/Loadbalancers/ListenerClient.php
+++ b/src/Loadbalancers/ListenerClient.php
@@ -52,7 +52,7 @@ class ListenerClient extends BaseClient implements ClientEntityInterface
 
     public function getEntityMap()
     {
-        return []; // needs to be empty so we can do custom hydration logic
+        return static::MAP;
     }
 
     public function friendlyToApi($item, $map)


### PR DESCRIPTION
I've tested this by editing the file in my vendor folder and creating, and updating listeners and also editing GeoIP settings. I don't think this change was actually needed in the final implementation of GeoIP and it's causing validation to fail as `cluster_id` is sent as `clusterId` without the map