### PR TITLE
Ecloud private volumes and volume groups

### DIFF
--- a/src/eCloud/Entities/Volume.php
+++ b/src/eCloud/Entities/Volume.php
@@ -14,6 +14,7 @@ use UKFast\SDK\Entity;
  * @property boolean $attached
  * @property string $sync
  * @property boolean $isShared
+ * @property bool $isPrivate
  * @property boolean $isEncrypted
  * @property string $volumeGroupId
  * @property integer $port
@@ -21,4 +22,21 @@ use UKFast\SDK\Entity;
 class Volume extends Entity
 {
     protected $dates = ['createdAt', 'updatedAt'];
+    public static $entityMap = [
+        'id' => 'id',
+        'name' => 'name',
+        'vpc_id' => 'vpcId',
+        'availability_zone_id' => 'availabilityZoneId',
+        'capacity' => 'capacity',
+        'iops' => 'iops',
+        'attached' => 'attached',
+        'sync' => 'sync',
+        'created_at' => 'createdAt',
+        'updated_at' => 'updatedAt',
+        'is_shared' => 'isShared',
+        'is_private' => 'isPrivate',
+        'is_encrypted' => 'isEncrypted',
+        'volume_group_id' => 'volumeGroupId',
+        'port' => 'port',
+    ];
 }

--- a/src/eCloud/Entities/VolumeGroup.php
+++ b/src/eCloud/Entities/VolumeGroup.php
@@ -9,10 +9,22 @@ use UKFast\SDK\Entity;
  * @property string $name
  * @property string $vpcId
  * @property string $availabilityZoneId
+ * @property bool $isPrivate
  * @property string sync
  * @property object $usage
  */
 class VolumeGroup extends Entity
 {
     protected $dates = ['createdAt', 'updatedAt'];
+    public static $entityMap = [
+        'id' => 'id',
+        'name' => 'name',
+        'vpc_id' => 'vpcId',
+        'availability_zone_id' => 'availabilityZoneId',
+        'is_private' => 'isPrivate',
+        'sync' => 'sync',
+        'usage' => 'usage',
+        'created_at' => 'createdAt',
+        'updated_at' => 'updatedAt',
+    ];
 }

--- a/src/eCloud/VolumeClient.php
+++ b/src/eCloud/VolumeClient.php
@@ -14,22 +14,7 @@ class VolumeClient extends Client implements ClientEntityInterface
 
     public function getEntityMap()
     {
-        return [
-            'id' => 'id',
-            'name' => 'name',
-            'vpc_id' => 'vpcId',
-            'availability_zone_id' => 'availabilityZoneId',
-            'capacity' => 'capacity',
-            'iops' => 'iops',
-            'attached' => 'attached',
-            'sync' => 'sync',
-            'created_at' => 'createdAt',
-            'updated_at' => 'updatedAt',
-            'is_shared' => 'isShared',
-            'is_encrypted' => 'isEncrypted',
-            'volume_group_id' => 'volumeGroupId',
-            'port' => 'port'
-        ];
+        return Volume::$entityMap;
     }
 
     public function loadEntity($data)

--- a/src/eCloud/VolumeGroupClient.php
+++ b/src/eCloud/VolumeGroupClient.php
@@ -14,16 +14,7 @@ class VolumeGroupClient extends Client implements ClientEntityInterface
 
     public function getEntityMap()
     {
-        return [
-            'id' => 'id',
-            'name' => 'name',
-            'vpc_id' => 'vpcId',
-            'availability_zone_id' => 'availabilityZoneId',
-            'sync' => 'sync',
-            'usage' => 'usage',
-            'created_at' => 'createdAt',
-            'updated_at' => 'updatedAt',
-        ];
+        return VolumeGroup::$entityMap;
     }
 
     public function loadEntity($data)


### PR DESCRIPTION
This pull request refactors how entity mapping is handled for the `Volume` and `VolumeGroup` entities and their respective clients. The main improvement is centralizing the entity mapping logic within the entity classes themselves, which simplifies and standardizes the way mappings are accessed by the client classes. Additionally, new properties (`isPrivate`) are introduced for both entities.

**Entity mapping centralization:**

- Added a static `$entityMap` property to both the `Volume` and `VolumeGroup` entity classes to define their field mappings in a single location. [[1]](diffhunk://#diff-2337bb899174edbb7db727351bd938a0693b70f4f014b7f0033e0fa6267de466R17-R41) [[2]](diffhunk://#diff-ee0fcfe6aaad50bb861eb5fc2d5819fcddda1b0ef046688057e177391c1d228fR12-R29)
- Updated the `getEntityMap()` methods in `VolumeClient` and `VolumeGroupClient` to return the respective entity's `$entityMap` property instead of having their own mapping arrays. [[1]](diffhunk://#diff-14198e778cb3886b8403ef472ea14ae51cf49f0aeab100f1cc147a2b818f1957L17-R17) [[2]](diffhunk://#diff-8fd22f0371d1374b48e0242183d9efc459aab2703433d2f42e19799ed23ed2aaL17-R17)

**Entity property updates:**

- Added a new `isPrivate` property to both `Volume` and `VolumeGroup` entities to support tracking of private volumes and groups. [[1]](diffhunk://#diff-2337bb899174edbb7db727351bd938a0693b70f4f014b7f0033e0fa6267de466R17-R41) [[2]](diffhunk://#diff-ee0fcfe6aaad50bb861eb5fc2d5819fcddda1b0ef046688057e177391c1d228fR12-R29)