### PR TITLE
Add domain registration support (v1 backport)

### DIFF
--- a/src/Domains/Client.php
+++ b/src/Domains/Client.php
@@ -24,4 +24,12 @@ class Client extends BaseClient
     {
         return (new WhoisClient($this->httpClient))->auth($this->token);
     }
+
+    /**
+     * @return BaseClient
+     */
+    public function registrar()
+    {
+        return (new DomainRegistrationClient($this->httpClient))->auth($this->token);
+    }
 }

--- a/src/Domains/DomainRegistrationClient.php
+++ b/src/Domains/DomainRegistrationClient.php
@@ -38,7 +38,7 @@ class DomainRegistrationClient extends BaseClient
         $response = $this->post('v2/domains', json_encode($registration->toApiArray()));
         $responseBody = $this->decodeJson($response->getBody()->getContents());
 
-        return (new SelfResponse($responseBody, 'name'))
+        return (new SelfResponse($responseBody))
             ->setClient($this)
             ->serializeWith(function ($responseBody) {
                 return new Domain($responseBody->data);

--- a/src/Domains/DomainRegistrationClient.php
+++ b/src/Domains/DomainRegistrationClient.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace UKFast\SDK\Domains;
+
+use UKFast\SDK\Client as BaseClient;
+use UKFast\SDK\Domains\Entities\Domain;
+use UKFast\SDK\Domains\Entities\DomainAvailability;
+use UKFast\SDK\Domains\Entities\DomainRegistration;
+use UKFast\SDK\SelfResponse;
+
+class DomainRegistrationClient extends BaseClient
+{
+    protected $basePath = 'registrar/';
+
+    /**
+     * Check whether a domain name is available for registration
+     *
+     * @param string $domainName
+     * @return DomainAvailability
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function checkAvailability($domainName)
+    {
+        $response = $this->post('v2/domains/availability', json_encode(['domain' => $domainName]));
+        $body = $this->decodeJson($response->getBody()->getContents());
+        return new DomainAvailability((array) $body->data);
+    }
+
+    /**
+     * Register a domain
+     *
+     * @param DomainRegistration $registration
+     * @return SelfResponse
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function register($registration)
+    {
+        $response = $this->post('v2/domains', json_encode($registration->toApiArray()));
+        $responseBody = $this->decodeJson($response->getBody()->getContents());
+
+        return (new SelfResponse($responseBody, 'name'))
+            ->setClient($this)
+            ->serializeWith(function ($responseBody) {
+                return new Domain($responseBody->data);
+            });
+    }
+}

--- a/src/Domains/Entities/DomainAvailability.php
+++ b/src/Domains/Entities/DomainAvailability.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace UKFast\SDK\Domains\Entities;
+
+use UKFast\SDK\Entity;
+
+/**
+ * @property string $domain
+ * @property bool $available
+ * @property DomainAvailabilityTerm[] $terms
+ */
+class DomainAvailability extends Entity
+{
+    public function __construct($attributes = [])
+    {
+        if (is_object($attributes)) {
+            $attributes = (array) $attributes;
+        }
+
+        if (isset($attributes['terms']) && is_array($attributes['terms'])) {
+            $attributes['terms'] = array_map(function ($term) {
+                return new DomainAvailabilityTerm((array) $term);
+            }, $attributes['terms']);
+        }
+
+        parent::__construct($attributes);
+    }
+}

--- a/src/Domains/Entities/DomainAvailabilityTerm.php
+++ b/src/Domains/Entities/DomainAvailabilityTerm.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace UKFast\SDK\Domains\Entities;
+
+use UKFast\SDK\Entity;
+
+/**
+ * @property int $period
+ * @property string $price
+ */
+class DomainAvailabilityTerm extends Entity
+{
+}

--- a/src/Domains/Entities/DomainRegistrant.php
+++ b/src/Domains/Entities/DomainRegistrant.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace UKFast\SDK\Domains\Entities;
+
+use UKFast\SDK\Entity;
+
+/**
+ * @property string|null $nominetId
+ * @property string|null $name
+ * @property string|null $type
+ * @property bool|null $privacy
+ * @property DomainRegistrantCompany|null $company
+ * @property DomainRegistrantContact|null $contact
+ * @property DomainRegistrantAddress|null $address
+ */
+class DomainRegistrant extends Entity
+{
+}

--- a/src/Domains/Entities/DomainRegistrantAddress.php
+++ b/src/Domains/Entities/DomainRegistrantAddress.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace UKFast\SDK\Domains\Entities;
+
+use UKFast\SDK\Entity;
+
+/**
+ * @property string $line1
+ * @property string|null $line2
+ * @property string $city
+ * @property string|null $county
+ * @property string $postcode
+ * @property string $country
+ */
+class DomainRegistrantAddress extends Entity
+{
+}

--- a/src/Domains/Entities/DomainRegistrantCompany.php
+++ b/src/Domains/Entities/DomainRegistrantCompany.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace UKFast\SDK\Domains\Entities;
+
+use UKFast\SDK\Entity;
+
+/**
+ * @property string|null $number
+ * @property string|null $tradingAs
+ */
+class DomainRegistrantCompany extends Entity
+{
+}

--- a/src/Domains/Entities/DomainRegistrantContact.php
+++ b/src/Domains/Entities/DomainRegistrantContact.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace UKFast\SDK\Domains\Entities;
+
+use UKFast\SDK\Entity;
+
+/**
+ * @property string $name
+ * @property string $email
+ * @property string|null $phone
+ */
+class DomainRegistrantContact extends Entity
+{
+}

--- a/src/Domains/Entities/DomainRegistration.php
+++ b/src/Domains/Entities/DomainRegistration.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace UKFast\SDK\Domains\Entities;
+
+use UKFast\SDK\Entity;
+
+/**
+ * @property string $name
+ * @property int $period
+ * @property array|null $nameservers
+ * @property bool|null $autoRenew
+ * @property DomainRegistrant|null $registrant
+ */
+class DomainRegistration extends Entity
+{
+    /**
+     * @return array
+     */
+    public function toApiArray()
+    {
+        $data = [
+            'name' => $this->name,
+            'period' => $this->period,
+        ];
+
+        if (!is_null($this->nameservers)) {
+            $data['nameservers'] = $this->nameservers;
+        }
+
+        if (!is_null($this->autoRenew)) {
+            $data['renewal'] = ['auto' => $this->autoRenew];
+        }
+
+        if (!is_null($this->registrant)) {
+            $data['registrant'] = $this->serialiseRegistrant($this->registrant);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param DomainRegistrant $registrant
+     * @return array
+     */
+    private function serialiseRegistrant($registrant)
+    {
+        $data = [];
+
+        if (!is_null($registrant->nominetId)) {
+            $data['nominet_id'] = $registrant->nominetId;
+        }
+
+        if (!is_null($registrant->name)) {
+            $data['name'] = $registrant->name;
+        }
+
+        if (!is_null($registrant->type)) {
+            $data['type'] = $registrant->type;
+        }
+
+        if (!is_null($registrant->privacy)) {
+            $data['privacy'] = $registrant->privacy;
+        }
+
+        if (!is_null($registrant->company)) {
+            $company = $registrant->company;
+            $companyData = [];
+
+            if (!is_null($company->number)) {
+                $companyData['number'] = $company->number;
+            }
+
+            if (!is_null($company->tradingAs)) {
+                $companyData['trading_as'] = $company->tradingAs;
+            }
+
+            if (!empty($companyData)) {
+                $data['company'] = $companyData;
+            }
+        }
+
+        if (!is_null($registrant->contact)) {
+            $contact = $registrant->contact;
+            $contactData = [
+                'name' => $contact->name,
+                'email' => $contact->email,
+            ];
+
+            if (!is_null($contact->phone)) {
+                $contactData['phone'] = $contact->phone;
+            }
+
+            $data['contact'] = $contactData;
+        }
+
+        if (!is_null($registrant->address)) {
+            $address = $registrant->address;
+            $addressData = [
+                'line1' => $address->line1,
+                'city' => $address->city,
+                'postcode' => $address->postcode,
+                'country' => $address->country,
+            ];
+
+            if (!is_null($address->line2)) {
+                $addressData['line2'] = $address->line2;
+            }
+
+            if (!is_null($address->county)) {
+                $addressData['county'] = $address->county;
+            }
+
+            $data['address'] = $addressData;
+        }
+
+        return $data;
+    }
+}

--- a/tests/Domains/DomainRegistrationClientTest.php
+++ b/tests/Domains/DomainRegistrationClientTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Domains;
+
+use GuzzleHttp\Client as Guzzle;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use UKFast\SDK\Domains\DomainRegistrationClient;
+use UKFast\SDK\Domains\Entities\DomainAvailability;
+use UKFast\SDK\Domains\Entities\DomainAvailabilityTerm;
+use UKFast\SDK\Domains\Entities\DomainRegistrant;
+use UKFast\SDK\Domains\Entities\DomainRegistrantAddress;
+use UKFast\SDK\Domains\Entities\DomainRegistrantContact;
+use UKFast\SDK\Domains\Entities\DomainRegistration;
+use UKFast\SDK\SelfResponse;
+
+class DomainRegistrationClientTest extends TestCase
+{
+    public function testCheckAvailabilityReturnsDomainAvailabilityEntity()
+    {
+        $data = [
+            'domain' => 'amazon.co.uk',
+            'available' => false,
+            'terms' => [
+                ['period' => 1, 'price' => '6.30'],
+                ['period' => 2, 'price' => '11.27'],
+            ],
+        ];
+
+        $mock = new MockHandler([
+            new Response(200, [], json_encode(['data' => $data, 'meta' => []]))
+        ]);
+        $client = new DomainRegistrationClient(new Guzzle(['handler' => HandlerStack::create($mock)]));
+
+        $result = $client->checkAvailability('amazon.co.uk');
+
+        $this->assertInstanceOf(DomainAvailability::class, $result);
+        $this->assertEquals('amazon.co.uk', $result->domain);
+        $this->assertFalse($result->available);
+        $this->assertCount(2, $result->terms);
+        $this->assertInstanceOf(DomainAvailabilityTerm::class, $result->terms[0]);
+        $this->assertEquals(1, $result->terms[0]->period);
+        $this->assertEquals('6.30', $result->terms[0]->price);
+        $this->assertEquals(2, $result->terms[1]->period);
+        $this->assertEquals('11.27', $result->terms[1]->price);
+    }
+
+    public function testRegisterReturnsSelfResponse()
+    {
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                'data' => ['name' => 'example.co.uk'],
+                'meta' => ['location' => 'https://api.ukfast.io/registrar/v2/domains/example.co.uk'],
+            ])),
+        ]);
+        $client = new DomainRegistrationClient(new Guzzle(['handler' => HandlerStack::create($mock)]));
+
+        $registration = new DomainRegistration([
+            'name' => 'example.co.uk',
+            'period' => 1,
+        ]);
+
+        $result = $client->register($registration);
+
+        $this->assertInstanceOf(SelfResponse::class, $result);
+        $this->assertEquals('example.co.uk', $result->getId());
+        $this->assertEquals(
+            'https://api.ukfast.io/registrar/v2/domains/example.co.uk',
+            $result->getLocation()
+        );
+    }
+
+    public function testToApiArrayOmitsNullValues()
+    {
+        $registration = new DomainRegistration([
+            'name' => 'example.co.uk',
+            'period' => 2,
+        ]);
+
+        $api = $registration->toApiArray();
+
+        $this->assertEquals(['name' => 'example.co.uk', 'period' => 2], $api);
+        $this->assertArrayNotHasKey('nameservers', $api);
+        $this->assertArrayNotHasKey('renewal', $api);
+        $this->assertArrayNotHasKey('registrant', $api);
+    }
+
+    public function testToApiArraySerializesNominetRegistrant()
+    {
+        $registrant = new DomainRegistrant([
+            'nominetId' => 'UK12345',
+        ]);
+
+        $registration = new DomainRegistration([
+            'name' => 'example.co.uk',
+            'period' => 1,
+            'registrant' => $registrant,
+        ]);
+
+        $api = $registration->toApiArray();
+
+        $this->assertEquals('UK12345', $api['registrant']['nominet_id']);
+        $this->assertArrayNotHasKey('contact', $api['registrant']);
+        $this->assertArrayNotHasKey('address', $api['registrant']);
+    }
+
+    public function testToApiArraySerializesOpenSrsRegistrant()
+    {
+        $contact = new DomainRegistrantContact([
+            'name' => 'John Smith',
+            'email' => 'john@example.com',
+            'phone' => '+44.1234567890',
+        ]);
+        $address = new DomainRegistrantAddress([
+            'line1' => '123 Test Street',
+            'city' => 'Manchester',
+            'county' => 'Greater Manchester',
+            'postcode' => 'M1 1AA',
+            'country' => 'GB',
+        ]);
+        $registrant = new DomainRegistrant([
+            'contact' => $contact,
+            'address' => $address,
+        ]);
+
+        $registration = new DomainRegistration([
+            'name' => 'example.com',
+            'period' => 1,
+            'autoRenew' => true,
+            'registrant' => $registrant,
+        ]);
+
+        $api = $registration->toApiArray();
+
+        $this->assertEquals(['auto' => true], $api['renewal']);
+        $this->assertEquals('John Smith', $api['registrant']['contact']['name']);
+        $this->assertEquals('john@example.com', $api['registrant']['contact']['email']);
+        $this->assertEquals('+44.1234567890', $api['registrant']['contact']['phone']);
+        $this->assertEquals('123 Test Street', $api['registrant']['address']['line1']);
+        $this->assertEquals('GB', $api['registrant']['address']['country']);
+        $this->assertArrayNotHasKey('line2', $api['registrant']['address']);
+    }
+}


### PR DESCRIPTION
- Add DomainRegistrationClient with checkAvailability() and register() methods
- Add DomainAvailability and DomainAvailabilityTerm response entities
- Add DomainRegistration request entity with toApiArray() serialisation
- Add DomainRegistrant, DomainRegistrantContact, DomainRegistrantAddress, DomainRegistrantCompany sub-entities
- Expose registrar() factory on Domains Client
- Add DomainRegistrationClientTest