### PR TITLE
Preserve request exception context

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -67,9 +67,9 @@ class Client
      *
      * @param string $method
      * @param string $endpoint
-     * @param string $body
+     * @param string|null $body
      * @param array $headers
-     * @throws GuzzleException
+     * @throws Exception\UKFastException
      * @return ResponseInterface
      */
     public function request($method, $endpoint, $body = null, $headers = [])
@@ -143,9 +143,9 @@ class Client
      * Convenience method for GET requests
      *
      * @param string $endpoint
-     * @param string $body
+     * @param string|null $body
      * @param array $headers
-     * @throws GuzzleException
+     * @throws Exception\UKFastException
      * @return ResponseInterface
      */
     public function get($endpoint, $body = null, $headers = [])
@@ -157,9 +157,9 @@ class Client
      * Convenience method for POST requests
      *
      * @param string $endpoint
-     * @param string $body
+     * @param string|null $body
      * @param array $headers
-     * @throws GuzzleException
+     * @throws Exception\UKFastException
      * @return ResponseInterface
      */
     public function post($endpoint, $body = null, $headers = [])
@@ -175,9 +175,9 @@ class Client
      * Convenience method for PUT requests
      *
      * @param string $endpoint
-     * @param string $body
+     * @param string|null $body
      * @param array $headers
-     * @throws GuzzleException
+     * @throws Exception\UKFastException
      * @return ResponseInterface
      */
     public function put($endpoint, $body = null, $headers = [])
@@ -193,9 +193,9 @@ class Client
      * Convenience method for PATCH requests
      *
      * @param string $endpoint
-     * @param string $body
+     * @param string|null $body
      * @param array $headers
-     * @throws GuzzleException
+     * @throws Exception\UKFastException
      * @return ResponseInterface
      */
     public function patch($endpoint, $body = null, $headers = [])
@@ -211,9 +211,9 @@ class Client
      * Convenience method for DELETE requests
      *
      * @param string $endpoint
-     * @param string $body
+     * @param string|null $body
      * @param array $headers
-     * @throws GuzzleException
+     * @throws Exception\UKFastException
      * @return ResponseInterface
      */
     public function delete($endpoint, $body = null, $headers = [])
@@ -233,7 +233,8 @@ class Client
      * @param int $perPage
      * @param array $filters
      * @param array $headers
-     * @throws GuzzleException
+     * @throws Exception\UKFastException
+     * @throws Exception\InvalidJsonException
      * @return Page
      */
     public function paginatedRequest($endpoint, $page, $perPage, $filters = [], $headers = [])

--- a/src/Client.php
+++ b/src/Client.php
@@ -6,6 +6,7 @@ use DateTime;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\ResponseInterface;
@@ -93,20 +94,46 @@ class Client
             $status = $e->getResponse()->getStatusCode();
 
             if ($status == 404) {
-                throw new Exception\NotFoundException($e->getResponse());
+                throw new Exception\NotFoundException($e->getResponse(), $e->getCode(), $e);
             }
 
             if ($status == 400 || $status == 422) {
-                throw new Exception\ValidationException($e->getResponse());
+                throw new Exception\ValidationException($e->getResponse(), $e->getCode(), $e);
             }
 
             if ($status == 412) {
-                throw new Exception\PreconditionFailedException($e->getResponse());
+                throw new Exception\PreconditionFailedException($e->getResponse(), $e->getCode(), $e);
             }
 
-            throw new Exception\ClientException($e->getResponse());
+            throw new Exception\ClientException($e->getResponse(), $e->getCode(), $e);
         } catch (ServerException $e) {
-            throw new Exception\ServerException($e->getResponse());
+            throw new Exception\ServerException($e->getResponse(), $e->getCode(), $e);
+        } catch (GuzzleRequestException $e) {
+            if ($e->hasResponse()) {
+                $status = $e->getResponse()->getStatusCode();
+
+                if ($status == 404) {
+                    throw new Exception\NotFoundException($e->getResponse(), $e->getCode(), $e);
+                }
+
+                if ($status == 400 || $status == 422) {
+                    throw new Exception\ValidationException($e->getResponse(), $e->getCode(), $e);
+                }
+
+                if ($status == 412) {
+                    throw new Exception\PreconditionFailedException($e->getResponse(), $e->getCode(), $e);
+                }
+
+                if ($status >= 500) {
+                    throw new Exception\ServerException($e->getResponse(), $e->getCode(), $e);
+                }
+
+                throw new Exception\ClientException($e->getResponse(), $e->getCode(), $e);
+            }
+
+            throw new Exception\RequestException($e->getMessage(), $e->getCode(), $e);
+        } catch (GuzzleException $e) {
+            throw new Exception\RequestException($e->getMessage(), $e->getCode(), $e);
         }
 
         return $response;

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -16,7 +16,7 @@ class ApiException extends UKFastException
      */
     protected $response;
 
-    public function __construct($response)
+    public function __construct($response, $code = 0, \Exception $previous = null)
     {
         $response->getBody()->rewind();
         $this->response = $response;
@@ -34,14 +34,15 @@ class ApiException extends UKFastException
             $this->errors = $this->getApiGatewayErrorFromBody($body);
         }
 
+        $message = '';
         if (!empty($this->errors)) {
             $message = $this->errors[0]->detail;
             if (empty($message)) {
                 $message = $this->errors[0]->title;
             }
-
-            $this->message = $message;
         }
+
+        parent::__construct($message, $code, $previous);
     }
 
     /**

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -16,7 +16,7 @@ class ApiException extends UKFastException
      */
     protected $response;
 
-    public function __construct($response, $code = 0, \Exception $previous = null)
+    public function __construct($response, $code = 0, $previous = null)
     {
         $response->getBody()->rewind();
         $this->response = $response;

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -4,8 +4,4 @@ namespace UKFast\SDK\Exception;
 
 class RequestException extends UKFastException
 {
-    public function __construct($message, $code = 0, \Exception $previous = null)
-    {
-        parent::__construct($message, $code, $previous);
-    }
 }

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -2,9 +2,7 @@
 
 namespace UKFast\SDK\Exception;
 
-use RuntimeException;
-
-class UKFastException extends RuntimeException
+class RequestException extends UKFastException
 {
     public function __construct($message, $code = 0, \Exception $previous = null)
     {

--- a/src/Exception/UKFastException.php
+++ b/src/Exception/UKFastException.php
@@ -6,7 +6,7 @@ use RuntimeException;
 
 class UKFastException extends RuntimeException
 {
-    public function __construct($message, $code = 0, \Exception $previous = null)
+    public function __construct($message, $code = 0, $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use DateTime;
 use GuzzleHttp\Client as Guzzle;
+use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Middleware;
@@ -13,8 +14,9 @@ use UKFast\SDK\Client;
 use UKFast\SDK\Exception\ApiException;
 use UKFast\SDK\Exception\InvalidJsonException;
 use UKFast\SDK\Exception\NotFoundException;
-use UKFast\SDK\Exception\ValidationException;
 use UKFast\SDK\Exception\PreconditionFailedException;
+use UKFast\SDK\Exception\RequestException as UKFastRequestException;
+use UKFast\SDK\Exception\ValidationException;
 use UKFast\SDK\Page;
 
 class ClientTest extends TestCase
@@ -234,6 +236,31 @@ class ClientTest extends TestCase
 
         $this->expectException(ValidationException::class);
         $client->paginatedRequest("/", 1, 10);
+    }
+
+    /**
+     * @test
+     */
+    public function preserves_the_original_exception_when_request_fails()
+    {
+        $request = new \GuzzleHttp\Psr7\Request('GET', '/');
+        $originalException = new GuzzleRequestException('Connection failed', $request);
+        $mock = new MockHandler([$originalException]);
+        $handler = HandlerStack::create($mock);
+        $guzzle = new Guzzle(['handler' => $handler]);
+        $client = new Client($guzzle);
+
+        $this->expectException(UKFastRequestException::class);
+        $this->expectExceptionMessage('Connection failed');
+
+        try {
+            $client->request('GET', '/');
+        } catch (UKFastRequestException $e) {
+            $this->assertInstanceOf(GuzzleRequestException::class, $e->getPrevious());
+            $this->assertSame($originalException, $e->getPrevious());
+            $this->assertSame('Connection failed', $e->getPrevious()->getMessage());
+            throw $e;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- preserve the original Guzzle request exception as the chained cause when request-level failures occur
- introduce a dedicated UKFast request exception for transport/request failures
- keep the SDK exception contract intact for request failures

## Testing
- docker run --rm -v "$PWD":/app -w /app php:8.2-cli bash -lc 'php vendor/phpunit/phpunit/phpunit --bootstrap tests/bootstrap.php tests/ApiExceptionTest.php tests/ClientTest.php'